### PR TITLE
Support ExtractTextWebpackPlugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ node_js:
 env:
   matrix:
     - WEBPACK_VERSION=1.13.1
-    - WEBPACK_VERSION=2.1.0-beta.20
+    - WEBPACK_VERSION=2.1.0-beta.20 EXTRACT_TEXT_VERSION=2.0.0-beta.3
 matrix:
   fast_finish: true
   allow_failures:
-    - env: WEBPACK_VERSION=2.1.0-beta.20
+    - env: WEBPACK_VERSION=2.1.0-beta.20 EXTRACT_TEXT_VERSION=2.0.0-beta.3
 before_script:
-  - npm rm webpack webpack-dev-server
-  - npm install webpack@$WEBPACK_VERSION
+  - npm rm webpack extract-text-webpack-plugin
+  - npm install webpack@$WEBPACK_VERSION extract-text-webpack-plugin@$EXTRACT_TEXT_VERSION
 cache:
   directories:
   - node_modules

--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ function CacheModule(cacheItem) {
     return exportName ? exportName : false;
   };
   this.strict = cacheItem.strict;
+  this.meta = cacheItem.meta;
   this.buildTimestamp = cacheItem.buildTimestamp;
   this.fileDependencies = cacheItem.fileDependencies;
   this.contextDependencies = cacheItem.contextDependencies;
@@ -463,6 +464,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           }, {}),
           buildTimestamp: module.buildTimestamp,
           strict: module.strict,
+          meta: module.meta,
 
           source: source.source(),
           map: devtoolOptions && source.map(devtoolOptions),

--- a/package.json
+++ b/package.json
@@ -19,13 +19,15 @@
     "url": "https://github.com/mzgoddard/hard-source-webpack-plugin/issues"
   },
   "scripts": {
-    "test": "mocha tests/base*.js"
+    "test": "mocha tests/base*.js tests/plugin*.js"
   },
   "author": "Michael \"Z\" Goddard <mzgoddard@gmail.com>",
   "license": "ISC",
   "devDependencies": {
     "bluebird": "^3.4.1",
     "chai": "^3.5.0",
+    "css-loader": "^0.23.1",
+    "extract-text-webpack-plugin": "^1.0.1",
     "memory-fs": "^0.3.0",
     "mocha": "^3.0.2",
     "rimraf": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/mzgoddard/hard-source-webpack-plugin/issues"
   },
   "scripts": {
-    "test": "mocha tests/base*.js tests/plugin*.js"
+    "test": "mocha tests/*.js"
   },
   "author": "Michael \"Z\" Goddard <mzgoddard@gmail.com>",
   "license": "ISC",
@@ -31,6 +31,7 @@
     "memory-fs": "^0.3.0",
     "mocha": "^3.0.2",
     "rimraf": "^2.5.4",
+    "style-loader": "^0.13.1",
     "webpack": "^1.13.1"
   },
   "peerDependencies": {

--- a/tests/fixtures/loader-css/index.css
+++ b/tests/fixtures/loader-css/index.css
@@ -1,0 +1,3 @@
+.hello {
+  color: blue;
+}

--- a/tests/fixtures/loader-css/index.js
+++ b/tests/fixtures/loader-css/index.js
@@ -1,0 +1,1 @@
+require('./index.css');

--- a/tests/fixtures/loader-css/webpack.config.js
+++ b/tests/fixtures/loader-css/webpack.config.js
@@ -1,0 +1,24 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  module: {
+    loaders: [
+      {
+        test: /\.css$/,
+        loader: 'style-loader!css-loader',
+      },
+    ],
+  },
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+    }),
+  ],
+};

--- a/tests/fixtures/plugin-extract-text/index.css
+++ b/tests/fixtures/plugin-extract-text/index.css
@@ -1,0 +1,3 @@
+.hello {
+  color: blue;
+}

--- a/tests/fixtures/plugin-extract-text/index.js
+++ b/tests/fixtures/plugin-extract-text/index.js
@@ -1,0 +1,1 @@
+require('./index.css');

--- a/tests/fixtures/plugin-extract-text/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text/webpack.config.js
@@ -1,6 +1,18 @@
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var ExtractTextVersion = require('extract-text-webpack-plugin/package.json').version;
 
 var HardSourceWebpackPlugin = require('../../..');
+
+var extractOptions;
+if (Number(ExtractTextVersion[0]) > 1) {
+  extractOptions = [{
+    fallbackLoader: 'style-loader',
+    loader: 'css-loader',
+  }];
+}
+else {
+  extractOptions = ['style-loader', 'css-loader'];
+}
 
 module.exports = {
   context: __dirname,
@@ -14,7 +26,8 @@ module.exports = {
     loaders: [
       {
         test: /\.css$/,
-        loaders: ExtractTextPlugin.extract('style-loader', 'css-loader'),
+        loader: ExtractTextPlugin.extract
+        .apply(ExtractTextPlugin, extractOptions),
       },
     ],
   },

--- a/tests/fixtures/plugin-extract-text/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text/webpack.config.js
@@ -1,0 +1,27 @@
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  module: {
+    loaders: [
+      {
+        test: /\.css$/,
+        loaders: ExtractTextPlugin.extract('style-loader', 'css-loader'),
+      },
+    ],
+  },
+  plugins: [
+    new ExtractTextPlugin('style.css'),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+    }),
+  ],
+};

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -1,0 +1,17 @@
+var expect = require('chai').expect;
+
+var util = require('./util');
+
+var clean = util.clean;
+
+describe('loader webpack use', function() {
+
+  before(function() {
+    return clean('loader-css');
+  });
+
+  it('builds identical loader-css fixture', function() {
+    return util.compileTwiceEqual('loader-css');
+  });
+
+});

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -1,0 +1,17 @@
+var expect = require('chai').expect;
+
+var util = require('./util');
+
+var clean = util.clean;
+
+describe('plugin webpack use', function() {
+
+  before(function() {
+    return clean('plugin-extract-text');
+  });
+
+  it('builds identical plugin-extract-text fixture', function() {
+    return util.compileTwiceEqual('plugin-extract-text');
+  });
+
+});

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -7,7 +7,7 @@ var rimraf = require('rimraf');
 var webpack = require('webpack');
 
 exports.compile = function(fixturePath) {
-  var configPath = path.join(__dirname, 'fixtures', fixturePath, 'webpack.config');
+  var configPath = path.join(__dirname, '..', 'fixtures', fixturePath, 'webpack.config');
   var compiler = webpack(require(configPath));
   var outputfs = compiler.outputFileSystem = new MemoryFS();
   var readdir = Promise.promisify(outputfs.readdir, {context: outputfs});
@@ -48,6 +48,6 @@ exports.compileTwiceEqual = function(fixturePath) {
 };
 
 exports.clean = function(fixturePath) {
-  var tmpPath = path.join(__dirname, 'fixtures', fixturePath, 'tmp');
+  var tmpPath = path.join(__dirname, '..', 'fixtures', fixturePath, 'tmp');
   return Promise.promisify(rimraf)(tmpPath);
 };


### PR DESCRIPTION
This plugin should be able to support operating alongside ExtractText since it is such a frequently utilized plugin.

Fixes #1.

TODO:

- [x] Write a test
- [x] Fulfill the test for webpack 1
- [x] Fulfill the test for webpack 2