### PR TITLE
Fix Uglify when devtool is not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -555,30 +555,31 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     }
 
     var devtoolOptions;
-  	if(compiler.options.devtool && (compiler.options.devtool.indexOf("sourcemap") >= 0 || compiler.options.devtool.indexOf("source-map") >= 0)) {
-  		var hidden = compiler.options.devtool.indexOf("hidden") >= 0;
-  		var inline = compiler.options.devtool.indexOf("inline") >= 0;
-  		var evalWrapped = compiler.options.devtool.indexOf("eval") >= 0;
-  		var cheap = compiler.options.devtool.indexOf("cheap") >= 0;
-  		var moduleMaps = compiler.options.devtool.indexOf("module") >= 0;
-  		var noSources = compiler.options.devtool.indexOf("nosources") >= 0;
-  		var legacy = compiler.options.devtool.indexOf("@") >= 0;
-  		var modern = compiler.options.devtool.indexOf("#") >= 0;
-  		var comment = legacy && modern ? "\n/*\n//@ sourceMappingURL=[url]\n//# sourceMappingURL=[url]\n*/" :
-  			legacy ? "\n/*\n//@ sourceMappingURL=[url]\n*/" :
-  			modern ? "\n//# sourceMappingURL=[url]" :
-  			null;
+    var devtool = compiler.options.devtool || compiler.options.devTool;
+    if(devtool && (devtool.indexOf("sourcemap") >= 0 || devtool.indexOf("source-map") >= 0)) {
+      var hidden = devtool.indexOf("hidden") >= 0;
+      var inline = devtool.indexOf("inline") >= 0;
+      var evalWrapped = devtool.indexOf("eval") >= 0;
+      var cheap = devtool.indexOf("cheap") >= 0;
+      var moduleMaps = devtool.indexOf("module") >= 0;
+      var noSources = devtool.indexOf("nosources") >= 0;
+      var legacy = devtool.indexOf("@") >= 0;
+      var modern = devtool.indexOf("#") >= 0;
+      var comment = legacy && modern ? "\n/*\n//@ sourceMappingURL=[url]\n//# sourceMappingURL=[url]\n*/" :
+        legacy ? "\n/*\n//@ sourceMappingURL=[url]\n*/" :
+        modern ? "\n//# sourceMappingURL=[url]" :
+        null;
       devtoolOptions = {
-  			filename: inline ? null : compiler.options.output.sourceMapFilename,
-  			moduleFilenameTemplate: compiler.options.output.devtoolModuleFilenameTemplate,
-  			fallbackModuleFilenameTemplate: compiler.options.output.devtoolFallbackModuleFilenameTemplate,
-  			append: hidden ? false : comment,
-  			module: moduleMaps ? true : cheap ? false : true,
-  			columns: cheap ? false : true,
-  			lineToLine: compiler.options.output.devtoolLineToLine,
-  			noSources: noSources,
-  		};
-  	}
+        filename: inline ? null : compiler.options.output.sourceMapFilename,
+        moduleFilenameTemplate: compiler.options.output.devtoolModuleFilenameTemplate,
+        fallbackModuleFilenameTemplate: compiler.options.output.devtoolFallbackModuleFilenameTemplate,
+        append: hidden ? false : comment,
+        module: moduleMaps ? true : cheap ? false : true,
+        columns: cheap ? false : true,
+        lineToLine: compiler.options.output.devtoolLineToLine,
+        noSources: noSources,
+      };
+    }
 
     // fs.writeFileSync(
     //   path.join(cacheDirPath, 'file-dependencies.json'),

--- a/tests/fixtures/plugin-extract-text-uglify-eval-source-map/index.css
+++ b/tests/fixtures/plugin-extract-text-uglify-eval-source-map/index.css
@@ -1,0 +1,3 @@
+.hello {
+  color: blue;
+}

--- a/tests/fixtures/plugin-extract-text-uglify-eval-source-map/index.js
+++ b/tests/fixtures/plugin-extract-text-uglify-eval-source-map/index.js
@@ -1,0 +1,1 @@
+require('./index.css');

--- a/tests/fixtures/plugin-extract-text-uglify-eval-source-map/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text-uglify-eval-source-map/webpack.config.js
@@ -1,0 +1,46 @@
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var ExtractTextVersion = require('extract-text-webpack-plugin/package.json').version;
+var UglifyJsPlugin = require('webpack').optimize.UglifyJsPlugin;
+
+var HardSourceWebpackPlugin = require('../../..');
+
+var extractOptions;
+if (Number(ExtractTextVersion[0]) > 1) {
+  extractOptions = [{
+    fallbackLoader: 'style-loader',
+    loader: 'css-loader',
+  }];
+}
+else {
+  extractOptions = ['style-loader', 'css-loader'];
+}
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  devtool: 'eval-source-map',
+  module: {
+    loaders: [
+      {
+        test: /\.css$/,
+        loader: ExtractTextPlugin.extract
+        .apply(ExtractTextPlugin, extractOptions),
+      },
+    ],
+  },
+  plugins: [
+    new ExtractTextPlugin('style.css'),
+    new UglifyJsPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/plugin-extract-text-uglify-source-map/index.css
+++ b/tests/fixtures/plugin-extract-text-uglify-source-map/index.css
@@ -1,0 +1,3 @@
+.hello {
+  color: blue;
+}

--- a/tests/fixtures/plugin-extract-text-uglify-source-map/index.js
+++ b/tests/fixtures/plugin-extract-text-uglify-source-map/index.js
@@ -1,0 +1,1 @@
+require('./index.css');

--- a/tests/fixtures/plugin-extract-text-uglify-source-map/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text-uglify-source-map/webpack.config.js
@@ -1,0 +1,46 @@
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var ExtractTextVersion = require('extract-text-webpack-plugin/package.json').version;
+var UglifyJsPlugin = require('webpack').optimize.UglifyJsPlugin;
+
+var HardSourceWebpackPlugin = require('../../..');
+
+var extractOptions;
+if (Number(ExtractTextVersion[0]) > 1) {
+  extractOptions = [{
+    fallbackLoader: 'style-loader',
+    loader: 'css-loader',
+  }];
+}
+else {
+  extractOptions = ['style-loader', 'css-loader'];
+}
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  devtool: 'source-map',
+  module: {
+    loaders: [
+      {
+        test: /\.css$/,
+        loader: ExtractTextPlugin.extract
+        .apply(ExtractTextPlugin, extractOptions),
+      },
+    ],
+  },
+  plugins: [
+    new ExtractTextPlugin('style.css'),
+    new UglifyJsPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/plugin-extract-text-uglify/index.css
+++ b/tests/fixtures/plugin-extract-text-uglify/index.css
@@ -1,0 +1,3 @@
+.hello {
+  color: blue;
+}

--- a/tests/fixtures/plugin-extract-text-uglify/index.js
+++ b/tests/fixtures/plugin-extract-text-uglify/index.js
@@ -1,0 +1,1 @@
+require('./index.css');

--- a/tests/fixtures/plugin-extract-text-uglify/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text-uglify/webpack.config.js
@@ -1,0 +1,45 @@
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var ExtractTextVersion = require('extract-text-webpack-plugin/package.json').version;
+var UglifyJsPlugin = require('webpack').optimize.UglifyJsPlugin;
+
+var HardSourceWebpackPlugin = require('../../..');
+
+var extractOptions;
+if (Number(ExtractTextVersion[0]) > 1) {
+  extractOptions = [{
+    fallbackLoader: 'style-loader',
+    loader: 'css-loader',
+  }];
+}
+else {
+  extractOptions = ['style-loader', 'css-loader'];
+}
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  module: {
+    loaders: [
+      {
+        test: /\.css$/,
+        loader: ExtractTextPlugin.extract
+        .apply(ExtractTextPlugin, extractOptions),
+      },
+    ],
+  },
+  plugins: [
+    new ExtractTextPlugin('style.css'),
+    new UglifyJsPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -6,6 +6,9 @@ describe('plugin webpack use', function() {
 
   itCompilesTwice('plugin-extract-text');
   itCompilesTwice('plugin-uglify-1dep');
+  itCompilesTwice('plugin-extract-text-uglify');
+  itCompilesTwice('plugin-extract-text-uglify-source-map');
+  itCompilesTwice('plugin-extract-text-uglify-eval-source-map');
   itCompilesTwice('plugin-isomorphic-tools');
 
 });


### PR DESCRIPTION
Fixes #5.

<del>ExtractText, Uglify, and source-maps together use source map features that are currently broken under HardSource.</del>

Uglify, unless its `sourceMap` option is explicitly set to false, uses source maps to give more clear warnings and errors. When it does this it sets `useSourceMap` on modules which when set we'll now store source maps without passed options. That'll retain the need source map info for Uglify to work.

- [x] Write a test
- [x] Ensure webpack 1 support
- [x] Ensure webpack 2 support