### PR TITLE
When invalidating skip already invalidated modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,6 +242,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         Object.keys(moduleCache).forEach(function(key) {
           if (key === 'fileDependencies') {return;}
           var module = moduleCache[key];
+          if (!module) {return;}
           if (typeof module === 'string') {
             module = JSON.parse(module);
             moduleCache[key] = module;

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -67,10 +67,20 @@ describe('basic webpack use builds changes', function() {
       'module.exports = 6;',
     ].join('\n'),
     'b/6/index.js': null,
+    // Change a second file make sure multiple invalidations don't
+    // break everything.
+    'b/7.js': [
+      'module.exports = 7;',
+    ].join('\n'),
+    'b/7/index.js': null,
   }, {
     'b/6.js': null,
     'b/6/index.js': [
       'module.exports = 6;',
+    ].join('\n'),
+    'b/7.js': null,
+    'b/7/index.js': [
+      'module.exports = 7;',
     ].join('\n'),
   }, function(output) {
     var oldId = /var b = module.exports =\n\s+__webpack_require__\((\d+)\)/

--- a/tests/fixtures/base-move-10deps-1nest/b/7.js
+++ b/tests/fixtures/base-move-10deps-1nest/b/7.js
@@ -1,1 +1,0 @@
-module.exports = 7;

--- a/tests/fixtures/base-move-10deps-1nest/b/7/index.js
+++ b/tests/fixtures/base-move-10deps-1nest/b/7/index.js
@@ -1,0 +1,1 @@
+module.exports = 7;


### PR DESCRIPTION
Fixes #8

Modules are invalidated by removing them from the cache. We currently
don't remove the keys with `delete`. We could visit that but either way
we should make sure the entry in `moduleCache` is an object.

This was causing a bug any time two resolutions were invalidated at the
same time.