### PR TITLE
Support dependency warnings by including `loc` info

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ function serializeDependencies(deps) {
           harmonyImportSpecifier: true,
           harmonyId: dep.id,
           harmonyName: dep.name,
+          loc: dep.loc,
         };
       }
     }
@@ -94,10 +95,12 @@ function serializeDependencies(deps) {
     }
     return {
       contextDependency: dep instanceof ContextDependency,
+      contextCritical: dep.critical,
       constDependency: dep instanceof ConstDependency,
       request: dep.request,
       recursive: dep.recursive,
       regExp: dep.regExp ? dep.regExp.source : null,
+      loc: dep.loc,
     };
   })
   .filter(function(req) {
@@ -303,7 +306,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         var validDepends = true;
         walkDependencyBlock(cacheItem, function(cacheDependency) {
           if (
-            !cacheDependency || typeof cacheDependency.request === 'undefined'
+            !cacheDependency ||
+            cacheDependency.contextDependency ||
+            typeof cacheDependency.request === 'undefined'
           ) {
             return;
           }

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -2,6 +2,12 @@ var ContextDependency = require('webpack/lib/dependencies/ContextDependency');
 var ModuleDependency = require('webpack/lib/dependencies/ModuleDependency');
 var NullDependency = require('webpack/lib/dependencies/NullDependency');
 
+var CriticalDependencyWarning;
+try {
+  CriticalDependencyWarning = require("webpack/lib/dependencies/CriticalDependencyWarning");
+}
+catch (_) {}
+
 var HarmonyModulesHelpers, HarmonyImportSpecifierDependency, HarmonyExportImportedSpecifierDependency;
 try {
   HarmonyModulesHelpers = require("webpack/lib/dependencies/HarmonyModulesHelpers");
@@ -31,6 +37,16 @@ function HardContextDependency(request, recursive, regExp) {
 }
 HardContextDependency.prototype = Object.create(ContextDependency.prototype);
 HardContextDependency.prototype.constructor = HardContextDependency;
+
+if (CriticalDependencyWarning) {
+  HardContextDependency.prototype.getWarnings = function() {
+    if(this.critical) {
+      return [
+        new CriticalDependencyWarning(this.critical)
+      ];
+    }
+  };
+}
 
 function HardNullDependency() {
   NullDependency.call(this);

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -71,7 +71,10 @@ function deserializeDependencies(deps, parent) {
   var lastImport;
   return deps.map(function(req) {
     if (req.contextDependency) {
-      return new HardContextDependency(req.request, req.recursive, req.regExp ? new RegExp(req.regExp) : null);
+      var dep = new HardContextDependency(req.request, req.recursive, req.regExp ? new RegExp(req.regExp) : null);
+      dep.critical = req.contextCritical;
+      dep.loc = req.loc;
+      return dep;
     }
     if (req.constDependency) {
       return new HardNullDependency();
@@ -83,7 +86,9 @@ function deserializeDependencies(deps, parent) {
       return lastImport = new HardHarmonyImportDependency(req.request);
     }
     if (req.harmonyImportSpecifier) {
-      return new HardHarmonyImportSpecifierDependency(lastImport, req.harmonyId, req.harmonyName);
+      var dep = new HardHarmonyImportSpecifierDependency(lastImport, req.harmonyId, req.harmonyName);
+      dep.loc = req.loc;
+      return dep;
     }
     if (req.harmonyExportImportedSpecifier) {
       return new HardHarmonyExportImportedSpecifierDependency(parent, lastImport, req.harmonyId, req.harmonyName);

--- a/tests/base-webpack-2.js
+++ b/tests/base-webpack-2.js
@@ -7,6 +7,7 @@ var describeWP2 = require('./util').describeWP2;
 describeWP2('basic webpack 2 use - compiles identically', function() {
 
   itCompilesTwice('base-es2015-module');
+  itCompilesTwice('base-warning-context');
   itCompilesTwice('base-warning-es2015');
 
 });

--- a/tests/base-webpack-2.js
+++ b/tests/base-webpack-2.js
@@ -7,6 +7,7 @@ var describeWP2 = require('./util').describeWP2;
 describeWP2('basic webpack 2 use - compiles identically', function() {
 
   itCompilesTwice('base-es2015-module');
+  itCompilesTwice('base-warning-es2015');
 
 });
 

--- a/tests/fixtures/base-warning-context/fib.js
+++ b/tests/fixtures/base-warning-context/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-warning-context/index.js
+++ b/tests/fixtures/base-warning-context/index.js
@@ -1,0 +1,1 @@
+var expr = require.context;

--- a/tests/fixtures/base-warning-context/webpack.config.js
+++ b/tests/fixtures/base-warning-context/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/base-warning-es2015/fib.js
+++ b/tests/fixtures/base-warning-es2015/fib.js
@@ -1,0 +1,3 @@
+export default function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+}

--- a/tests/fixtures/base-warning-es2015/index.js
+++ b/tests/fixtures/base-warning-es2015/index.js
@@ -1,0 +1,2 @@
+import {warning} from './obj';
+console.log(warning);

--- a/tests/fixtures/base-warning-es2015/obj.js
+++ b/tests/fixtures/base-warning-es2015/obj.js
@@ -1,0 +1,3 @@
+import fib from './fib';
+let key = 'obj';
+export {key, fib};

--- a/tests/fixtures/base-warning-es2015/webpack.config.js
+++ b/tests/fixtures/base-warning-es2015/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Fixes #16

Dependency warnings for es2015 dependencies and others should be supported. To do so we need to include `loc` info so that webpack can build the warning.

- [x] Add a test
- [x] Include loc info
- [x] Support context critical warning