### PR TITLE
Fix use with DllPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -573,9 +573,12 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           moduleId: module.id,
           context: module.context,
           request: module.request,
+          userRequest: module.userRequest,
           identifier: module.identifier(),
           readableIdentifier: module
           .readableIdentifier(compilation.moduleTemplate.requestShortener),
+          // libIdent: module.libIdent &&
+          // module.libIdent({context: compiler.options.context}),
           assets: Object.keys(module.assets || {}),
           buildTimestamp: module.buildTimestamp,
           strict: module.strict,

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 var AsyncDependenciesBlock = require('webpack/lib/AsyncDependenciesBlock');
 var DependenciesBlockVariable = require('webpack/lib/DependenciesBlockVariable');
 var RawModule = require('webpack/lib/RawModule');
@@ -61,6 +63,26 @@ HardModule.prototype.source = function() {
 
 HardModule.prototype.updateHash = function(hash) {
   hash.update(this.cacheItem.hashContent);
+};
+
+// HardModule.prototype.libIdent = function(options) {
+//   return this.cacheItem.libIdent;
+// };
+
+// From webpack/lib/NormalModule.js
+function contextify(options, request) {
+  return request.split("!").map(function(r) {
+    var rp = path.relative(options.context, r);
+    if(path.sep === "\\")
+      rp = rp.replace(/\\/g, "/");
+    if(rp.indexOf("../") !== 0)
+      rp = "./" + rp;
+    return rp;
+  }).join("!");
+}
+
+HardModule.prototype.libIdent = function(options) {
+  return contextify(options, this.cacheItem.userRequest);
 };
 
 // HardModule.prototype.isUsed = function(exportName) {

--- a/tests/fixtures/plugin-dll-reference/dll-manifest.json
+++ b/tests/fixtures/plugin-dll-reference/dll-manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "dll_c640cf83e777b7d462d5",
+  "content": {
+    "./fib.js": {
+      "id": 0,
+      "meta": {},
+      "hasStarExport": false,
+      "activeExports": []
+    }
+  }
+}

--- a/tests/fixtures/plugin-dll-reference/dll.js
+++ b/tests/fixtures/plugin-dll-reference/dll.js
@@ -1,0 +1,84 @@
+var dll_c640cf83e777b7d462d5 =
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmory imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmory exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		Object.defineProperty(exports, name, {
+/******/ 			configurable: false,
+/******/ 			enumerable: true,
+/******/ 			get: getter
+/******/ 		});
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__;
+
+/***/ }
+/******/ ]);

--- a/tests/fixtures/plugin-dll-reference/fib.js
+++ b/tests/fixtures/plugin-dll-reference/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/plugin-dll-reference/index.js
+++ b/tests/fixtures/plugin-dll-reference/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/plugin-dll-reference/webpack.config.js
+++ b/tests/fixtures/plugin-dll-reference/webpack.config.js
@@ -1,0 +1,25 @@
+var DllReferencePlugin = require('webpack').DllReferencePlugin;
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+    library: '[name]_[hash]',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+    new DllReferencePlugin({
+      manifest: require('./dll-manifest.json'),
+      context: __dirname,
+    }),
+  ],
+};

--- a/tests/fixtures/plugin-dll/fib.js
+++ b/tests/fixtures/plugin-dll/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/plugin-dll/index.js
+++ b/tests/fixtures/plugin-dll/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/plugin-dll/webpack.config.js
+++ b/tests/fixtures/plugin-dll/webpack.config.js
@@ -1,0 +1,28 @@
+var DllPlugin = require('webpack').DllPlugin;
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: {
+    'dll': ['./fib.js'],
+  },
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'dll.js',
+    library: '[name]_[hash]',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+    new DllPlugin({
+      path: __dirname + '/tmp/dll-manifest.json',
+      name: '[name]_[hash]',
+      // context: __dirname,
+    }),
+  ],
+};

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -4,6 +4,8 @@ var itCompilesTwice = require('./util').itCompilesTwice;
 
 describe('plugin webpack use', function() {
 
+  itCompilesTwice('plugin-dll');
+  itCompilesTwice('plugin-dll-reference');
   itCompilesTwice('plugin-extract-text');
   itCompilesTwice('plugin-uglify-1dep');
   itCompilesTwice('plugin-extract-text-uglify');


### PR DESCRIPTION
Related to #18

DllPlugin needs a method on modules to work called `libIdent` to build
an identier that DllReferencePlugin uses to see if it should use the
dll contained module instead of letting a normal module be built.