### PR TITLE
Better stand up harmony dependency imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ function serializeDependencies(deps) {
       }
       if (dep instanceof HarmonyExportImportedSpecifierDependency) {
         return {
+          harmonyRequest: dep.importDependency.request,
           harmonyExportImportedSpecifier: true,
           harmonyId: dep.id,
           harmonyName: dep.name,
@@ -78,6 +79,7 @@ function serializeDependencies(deps) {
       }
       if (dep instanceof HarmonyImportSpecifierDependency) {
         return {
+          harmonyRequest: dep.importDependency.request,
           harmonyImportSpecifier: true,
           harmonyId: dep.id,
           harmonyName: dep.name,

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -90,7 +90,6 @@ HardModule.prototype.libIdent = function(options) {
 // };
 
 function deserializeDependencies(deps, parent) {
-  var lastImport;
   return deps.map(function(req) {
     if (req.contextDependency) {
       var dep = new HardContextDependency(req.request, req.recursive, req.regExp ? new RegExp(req.regExp) : null);
@@ -105,34 +104,34 @@ function deserializeDependencies(deps, parent) {
       return new HardHarmonyExportDependency(parent, req.harmonyId, req.harmonyName, req.harmonyPrecedence);
     }
     if (req.harmonyImport) {
-      return lastImport = new HardHarmonyImportDependency(req.request);
+      return this.state.imports[req.request] = new HardHarmonyImportDependency(req.request);
     }
     if (req.harmonyImportSpecifier) {
-      var dep = new HardHarmonyImportSpecifierDependency(lastImport, req.harmonyId, req.harmonyName);
+      var dep = new HardHarmonyImportSpecifierDependency(this.state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
       dep.loc = req.loc;
       return dep;
     }
     if (req.harmonyExportImportedSpecifier) {
-      return new HardHarmonyExportImportedSpecifierDependency(parent, lastImport, req.harmonyId, req.harmonyName);
+      return new HardHarmonyExportImportedSpecifierDependency(parent, this.state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
     }
     return new HardModuleDependency(req.request);
-  });
+  }, this);
 }
 function deserializeVariables(vars, parent) {
   return vars.map(function(req) {
-    return new DependenciesBlockVariable(req.name, req.expression, deserializeDependencies(req.dependencies, parent));
-  });
+    return new DependenciesBlockVariable(req.name, req.expression, deserializeDependencies.call(this, req.dependencies, parent));
+  }, this);
 }
 function deserializeBlocks(blocks, parent) {
   blocks.map(function(req) {
     if (req.async) {
       var block = new AsyncDependenciesBlock(req.name, parent);
-      block.dependencies = deserializeDependencies(req.dependencies, parent);
-      block.variables = deserializeVariables(req.variables, parent);
+      block.dependencies = deserializeDependencies.call(this, req.dependencies, parent);
+      block.variables = deserializeVariables.call(this, req.variables, parent);
       deserializeBlocks(req.blocks, block);
       return block;
     }
-  })
+  }, this)
   .filter(Boolean)
   .forEach(function(block) {
     parent.addBlock(block);
@@ -147,9 +146,10 @@ HardModule.prototype.build = function build(options, compilation, resolver, fs, 
   // Rendered source used in built output.
   this._renderedSource = new HardSource(this.cacheItem);
 
-  this.dependencies = deserializeDependencies(this.cacheItem.dependencies, this);
-  this.variables = deserializeVariables(this.cacheItem.variables, this);
-  deserializeBlocks(this.cacheItem.blocks, this);
+  var state = {state: {imports: {}}};
+  this.dependencies = deserializeDependencies.call(state, this.cacheItem.dependencies, this);
+  this.variables = deserializeVariables.call(state, this.cacheItem.variables, this);
+  deserializeBlocks.call(state, this.cacheItem.blocks, this);
 
   var cacheItem = this.cacheItem;
   this.assets = Object.keys(cacheItem.assets).reduce(function(carry, key) {

--- a/tests/base-webpack-2.js
+++ b/tests/base-webpack-2.js
@@ -7,6 +7,7 @@ var describeWP2 = require('./util').describeWP2;
 describeWP2('basic webpack 2 use - compiles identically', function() {
 
   itCompilesTwice('base-es2015-module');
+  itCompilesTwice('base-es2015-rename-module');
   itCompilesTwice('base-warning-context');
   itCompilesTwice('base-warning-es2015');
 

--- a/tests/fixtures/base-es2015-rename-module/fact.js
+++ b/tests/fixtures/base-es2015-rename-module/fact.js
@@ -1,0 +1,3 @@
+export default function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-es2015-rename-module/fib.js
+++ b/tests/fixtures/base-es2015-rename-module/fib.js
@@ -1,0 +1,3 @@
+export default function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-es2015-rename-module/index.js
+++ b/tests/fixtures/base-es2015-rename-module/index.js
@@ -1,0 +1,6 @@
+import {key as _key} from './key';
+import {key as __key} from './obj';
+import fibfib from './fib';
+import factfact from './fact';
+
+console.log(_key, __key, factfact, fibfib(3));

--- a/tests/fixtures/base-es2015-rename-module/key.js
+++ b/tests/fixtures/base-es2015-rename-module/key.js
@@ -1,0 +1,1 @@
+export var key = 'keykey';

--- a/tests/fixtures/base-es2015-rename-module/obj.js
+++ b/tests/fixtures/base-es2015-rename-module/obj.js
@@ -1,0 +1,3 @@
+import fib from './fib';
+let key = 'obj';
+export {key, fib};

--- a/tests/fixtures/base-es2015-rename-module/webpack.config.js
+++ b/tests/fixtures/base-es2015-rename-module/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Visiting a follow up for #16, we can see while we are getting warnings they are pointing to the import graph being inaccurate. The dependency storing and standing back up were too simple and so incorrect. They need to store the request for a import specifier and use that request to find the correct import.