### PR TITLE
[WIP] The One with the Plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -753,7 +753,7 @@ NormalModuleThawPlugin.prototype.apply = function(hardSource) {
   new AssetCachePlugin().apply(hardSource);
 
   hardSource.plugin('compiler', function(compiler) {
-    compiler.plugin('compilation', function(compliation, params) {
+    compiler.plugin('compilation', function(compilation, params) {
       var fileTimestamps = FileTimestampPlugin.getStamps(hardSource);
       var assetCache = AssetCachePlugin.getCache(hardSource);
       var moduleCache = ModuleCachePlugin.getCache(hardSource);
@@ -790,6 +790,7 @@ NormalModuleThawPlugin.prototype.apply = function(hardSource) {
                 compiler.contextTimestamps
               )) {
                 var module = new HardModule(cacheItem);
+                module[extractTextNS] = cacheItem.extractTextPluginMeta;
                 return cb(null, module);
               }
             }

--- a/index.js
+++ b/index.js
@@ -631,7 +631,7 @@ NormalModuleFreezePlugin.prototype.apply = function(hardSource) {
   }
 
   hardSource.plugin('freeze-module-data', function(moduleOut, compilation) {
-    compilation.modules.forEach(function(module, cb) {
+    compilation.modules.forEach(function(module) {
       var devtoolOptions = hardSource.getDevtoolOptions();
 
       var identifierPrefix = cachePrefix(compilation);
@@ -703,7 +703,7 @@ NormalModuleFreezePlugin.prototype.apply = function(hardSource) {
         // These modules must always be built so the child compilers run so
         // that assets get built.
         if (module[extractTextNS] || module.meta[extractTextNS]) {
-          moduleOut[identifier] = null;
+          delete moduleOut[identifier];
           return;
         }
       }
@@ -761,14 +761,15 @@ NormalModuleThawPlugin.prototype.apply = function(hardSource) {
       params.normalModuleFactory.plugin('resolver', function(fn) {
         return function(request, cb) {
           fn.call(null, request, function(err, result) {
+            if (err) {return cb(err);}
+
             var identifierPrefix = cachePrefix(compilation);
             if (identifierPrefix === null) {
               return cb(err, result);
             }
             var identifier = identifierPrefix + result.request;
 
-            if (err) {return cb(err);}
-            else if (moduleCache[identifier]) {
+            if (moduleCache[identifier]) {
               var cacheItem = moduleCache[identifier];
               if (typeof cacheItem === 'string') {
                 cacheItem = JSON.parse(cacheItem);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var path = require('path');
 var level = require('level');
 var lodash = require('lodash');
 var mkdirp = require('mkdirp');
+var Tapable = require('tapable');
 
 var Promise = require('bluebird');
 
@@ -55,6 +56,8 @@ var makeDevtoolOptions = require('./lib/devtool-options');
 function requestHash(request) {
   return crypto.createHash('sha1').update(request).digest().hexSlice();
 }
+
+var promisify = Promise.promisify;
 
 var fsReadFile = Promise.promisify(fs.readFile, {context: fs});
 var fsStat = Promise.promisify(fs.stat, {context: fs});
@@ -143,78 +146,47 @@ function flattenPrototype(obj) {
   return copy;
 }
 
+function serializeError(error) {
+  var serialized = {
+    message: error.message,
+  };
+  if (error.origin) {
+    serialized.origin = serializeDependencies([error.origin])[0];
+  }
+  if (error.dependencies) {
+    serialized.dependencies = serializeDependencies(error.dependencies);
+  }
+  return serialized;
+}
 function serializeDependencies(deps) {
   return deps
   .map(function(dep) {
-    if (typeof HarmonyImportDependency !== 'undefined') {
-      if (dep instanceof HarmonyImportDependency) {
-        return {
-          harmonyImport: true,
-          request: dep.request,
-        };
-      }
-      if (dep instanceof HarmonyExportImportedSpecifierDependency) {
-        return {
-          harmonyRequest: dep.importDependency.request,
-          harmonyExportImportedSpecifier: true,
-          harmonyId: dep.id,
-          harmonyName: dep.name,
-        };
-      }
-      if (dep instanceof HarmonyImportSpecifierDependency) {
-        return {
-          harmonyRequest: dep.importDependency.request,
-          harmonyImportSpecifier: true,
-          harmonyId: dep.id,
-          harmonyName: dep.name,
-          loc: dep.loc,
-        };
-      }
-    }
-    if (dep.originModule) {
-      return {
-        harmonyExport: true,
-        harmonyId: dep.id,
-        harmonyName: dep.describeHarmonyExport().exportedName,
-        harmonyPrecedence: dep.describeHarmonyExport().precedence,
-      };
-    }
-    return {
-      contextDependency: dep instanceof ContextDependency,
-      contextCritical: dep.critical,
-      constDependency: (
-        dep instanceof ConstDependency ||
-        dep instanceof AMDDefineDependency
-      ),
-      request: dep.request,
-      recursive: dep.recursive,
-      regExp: dep.regExp ? dep.regExp.source : null,
-      loc: flattenPrototype(dep.loc),
-    };
-  })
-  .filter(function(req) {
-    return req.request || req.constDependency || req.harmonyExport || req.harmonyImportSpecifier || req.harmonyExportImportedSpecifier;
-  });
+    return this.applyPluginsWaterfall('freeze-dependency', null, dep);
+  }, this)
+  .filter(Boolean);
+  // .filter(function(req) {
+  //   return req.request || req.constDependency || req.harmonyExport || req.harmonyImportSpecifier || req.harmonyExportImportedSpecifier;
+  // });
 }
 function serializeVariables(vars) {
   return vars.map(function(variable) {
     return {
       name: variable.name,
       expression: variable.expression,
-      dependencies: serializeDependencies(variable.dependencies),
+      dependencies: serializeDependencies.call(this, variable.dependencies),
     }
-  });
+  }, this);
 }
 function serializeBlocks(blocks) {
   return blocks.map(function(block) {
     return {
       async: block instanceof AsyncDependenciesBlock,
       name: block.chunkName,
-      dependencies: serializeDependencies(block.dependencies),
-      variables: serializeVariables(block.variables),
-      blocks: serializeBlocks(block.blocks),
+      dependencies: serializeDependencies.call(this, block.dependencies),
+      variables: serializeVariables.call(this, block.variables),
+      blocks: serializeBlocks.call(this, block.blocks),
     };
-  });
+  }, this);
 }
 function serializeHashContent(module) {
   var content = [];
@@ -243,9 +215,571 @@ function serializeHashContent(module) {
 //
 // };
 
-function HardSourceWebpackPlugin(options) {
-  this.options = options;
+function DependencySerializePlugin() {
 }
+
+DependencySerializePlugin.prototype.apply = function(hardSource) {
+  hardSource.plugin('freeze-dependency', function(carry, dep) {
+    if (dep instanceof ContextDependency) {
+      return {
+        contextDependency: dep instanceof ContextDependency,
+        contextCritical: dep.critical,
+        request: dep.request,
+        recursive: dep.recursive,
+        regExp: dep.regExp ? dep.regExp.source : null,
+        loc: flattenPrototype(dep.loc),
+      };
+    }
+    if (
+      dep instanceof ConstDependency ||
+      dep instanceof AMDDefineDependency
+    ) {
+      return {
+        constDependency: true,
+      };
+    }
+    if (dep.request) {
+      return {
+        request: dep.request,
+        loc: flattenPrototype(dep.loc),
+      };
+    }
+    return carry;
+  });
+};
+
+function DependencyThawPlugin() {
+}
+
+DependencyThawPlugin.prototype.apply = function(hardSource) {
+  hardSource.plugin('thaw-dependency', function(carry, req) {
+    if (req.contextDependency) {
+      var dep = new HardContextDependency(req.request, req.recursive, req.regExp ? new RegExp(req.regExp) : null);
+      dep.critical = req.contextCritical;
+      dep.loc = req.loc;
+      return dep;
+    }
+    if (req.constDependency) {
+      return new HardNullDependency();
+    }
+
+    var dep = new HardModuleDependency(req.request);
+    dep.loc = req.loc;
+    return dep;
+  });
+};
+
+function HarmonyDependencySerializePlugin() {
+}
+
+HarmonyDependencySerializePlugin.prototype.apply = function(hardSource) {
+  if (typeof HarmonyImportDependency === 'undefined') {
+    return;
+  }
+
+  hardSource.plugin('freeze-dependency', function(carry, dep) {
+    if (dep instanceof HarmonyImportDependency) {
+      return {
+        harmonyImport: true,
+        request: dep.request,
+      };
+    }
+    if (dep instanceof HarmonyExportImportedSpecifierDependency) {
+      return {
+        harmonyRequest: dep.importDependency.request,
+        harmonyExportImportedSpecifier: true,
+        harmonyId: dep.id,
+        harmonyName: dep.name,
+      };
+    }
+    if (dep instanceof HarmonyImportSpecifierDependency) {
+      return {
+        harmonyRequest: dep.importDependency.request,
+        harmonyImportSpecifier: true,
+        harmonyId: dep.id,
+        harmonyName: dep.name,
+        loc: dep.loc,
+      };
+    }
+    if (dep.originModule) {
+      return {
+        harmonyExport: true,
+        harmonyId: dep.id,
+        harmonyName: dep.describeHarmonyExport().exportedName,
+        harmonyPrecedence: dep.describeHarmonyExport().precedence,
+      };
+    }
+    return carry;
+  });
+}
+
+function HarmonyDependencyThawPlugin() {
+}
+
+HarmonyDependencyThawPlugin.prototype.apply = function(hardSource) {
+  if (typeof HarmonyImportDependency === 'undefined') {
+    return;
+  }
+
+  hardSource.plugin('thaw-dependency', function(carry, req, state) {
+    if (req.harmonyExport) {
+      return new HardHarmonyExportDependency(parent, req.harmonyId, req.harmonyName, req.harmonyPrecedence);
+    }
+    if (req.harmonyImport) {
+      if (state.imports[req.request]) {
+        return state.imports[req.request];
+      }
+      return state.imports[req.request] = new HardHarmonyImportDependency(req.request);
+    }
+    if (req.harmonyImportSpecifier) {
+      var dep = new HardHarmonyImportSpecifierDependency(state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
+      dep.loc = req.loc;
+      return dep;
+    }
+    if (req.harmonyExportImportedSpecifier) {
+      if (!state.imports[req.harmonyRequest]) {
+        state.imports[req.harmonyRequest] = new HardHarmonyImportDependency(req.harmonyRequest);
+      }
+      return new HardHarmonyExportImportedSpecifierDependency(parent, state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
+    }
+    return carry;
+  });
+};
+
+function ModuleSerializePlugin() {
+}
+
+ModuleSerializePlugin.prototype.apply = function(hardSource) {
+  hardSource.plugin('freeze-module', function(carry, module, compilation) {
+    var devtoolOptions = this.devtoolOptions;
+
+    var identifierPrefix = cachePrefix(compilation);
+    if (identifierPrefix === null) {
+      return;
+    }
+    var identifier = identifierPrefix + module.identifier();
+
+    var existingCacheItem = this.getModuleCache()[identifier];
+
+    if (
+      module.request &&
+      module.cacheable &&
+      !(module instanceof HardModule) &&
+      (module instanceof NormalModule) &&
+      (
+        existingCacheItem &&
+        module.buildTimestamp > existingCacheItem.buildTimestamp ||
+        !existingCacheItem
+      )
+    ) {
+      var source = module.source(
+        compilation.dependencyTemplates,
+        compilation.moduleTemplate.outputOptions, 
+        compilation.moduleTemplate.requestShortener
+      );
+      return {
+        moduleId: module.id,
+        context: module.context,
+        request: module.request,
+        userRequest: module.userRequest,
+        rawRequest: module.rawRequest,
+        resource: module.resource,
+        loaders: module.loaders,
+        identifier: module.identifier(),
+        // libIdent: module.libIdent &&
+        // module.libIdent({context: compiler.options.context}),
+        assets: Object.keys(module.assets || {}),
+        buildTimestamp: module.buildTimestamp,
+        strict: module.strict,
+        meta: module.meta,
+        used: module.used,
+        usedExports: module.usedExports,
+
+        rawSource: module._source ? module._source.source() : null,
+        source: source.source(),
+        map: devtoolOptions && source.map(devtoolOptions),
+        // Some plugins (e.g. UglifyJs) set useSourceMap on a module. If that
+        // option is set we should always store some source map info and
+        // separating it from the normal devtool options may be necessary.
+        baseMap: module.useSourceMap && source.map(),
+        hashContent: serializeHashContent(module),
+
+        dependencies: serializeDependencies.call(this, module.dependencies),
+        variables: serializeVariables.call(this, module.variables),
+        blocks: serializeBlocks.call(this, module.blocks),
+
+        fileDependencies: module.fileDependencies,
+        contextDependencies: module.contextDependencies,
+
+        errors: module.errors.map(serializeError),
+        warnings: module.warnings.map(serializeError),
+      };
+    }
+    return carry;
+  });
+
+  hardSource.plugin('freeze-asset', function(carry, asset, module) {
+    return asset.source();
+  });
+};
+
+function FileTimestampPlugin() {}
+
+FileTimestampPlugin.getStamps = function(hardSource) {
+  return hardSource.__fileTimestampPlugin.fileTimestamps;
+};
+
+FileTimestampPlugin.prototype.apply = function(hardSource) {
+  if (hardSource.__fileTimestampPlugin) {return;}
+
+  var _this = hardSource.__fileTimestampPlugin = this;
+
+  hardSource.plugin('reset', function() {
+    _this.fileDependencies = {};
+  });
+
+  hardSource.plugin('compiler', function(compiler) {
+    compiler.plugin('compilation', function(compilation) {
+      compilation.fileTimestamps = _this.fileTimestamps;
+    });
+  });
+
+  hardSource.plugin('before-dependency-bust', function(cb) {
+    var dataCache = this.getDataCache();
+    // if(!this.cache.data.fileDependencies) return cb();
+    // var fs = compiler.inputFileSystem;
+    var fileTs = this.compiler.fileTimestamps = _this.fileTimestamps = {};
+
+    return Promise.all((dataCache.fileDependencies || []).map(function(file) {
+      return fsStat(file)
+      .then(function(stat) {
+        fileTs[file] = stat.mtime || Infinity;
+      }, function(err) {
+        fileTs[file] = 0;
+
+        if (err.code === "ENOENT") {return;}
+        throw err;
+      });
+    }))
+    .then(function() {cb();}, cb);
+  });
+
+  hardSource.plugin('freeze-compilation-data', function(out, compilation) {
+    var dataCache = this.getDataCache();
+
+    var fileDependenciesDiff = lodash.difference(
+      compilation.fileDependencies,
+      dataCache.fileDependencies || []
+    );
+    if (fileDependenciesDiff.length) {
+      dataCache.fileDependencies = (dataCache.fileDependencies || [])
+      .concat(fileDependenciesDiff);
+
+      out.fileDependencies = dataCache.fileDependencies;
+    }
+  });
+};
+
+function ResolveCachePlugin() {}
+
+ResolveCachePlugin.prototype.apply = function(hardSource) {
+  new FileTimestampPlugin().apply(hardSource);
+
+  var resolveCache = {};
+
+  hardSource.plugin('reset', function() {
+    resolveCache = {};
+  });
+
+  hardSource.plugin('thaw-compilation-data', function(dataCache) {
+    resolveCache = dataCache.resolve;
+  });
+
+  hardSource.plugin('freeze-compilation-data', function(dataOut) {
+    dataOut.resolve = resolveCache;
+  });
+
+  hardSource.plugin('compiler', function(compiler) {
+    compiler.plugin('compilation', function(compilation, params) {
+      var fileTimestamps = FileTimestampPlugin.getStamps(hardSource);
+
+      // Webpack 2 can use different parsers based on config rule sets.
+      params.normalModuleFactory.plugin('parser', function(parser, options) {
+        // Store the options somewhere that can not conflict with another plugin
+        // on the parser so we can look it up and store those options with a
+        // cached module resolution.
+        parser[NS + '/parser-options'] = options;
+      });
+
+      params.normalModuleFactory.plugin('resolver', function(fn) {
+        return function(request, cb) {
+          var cacheId = JSON.stringify([request.context, request.request]);
+
+          var next = function() {
+            var originalRequest = request;
+            return fn.call(null, request, function(err, request) {
+              if (err) {
+                return cb(err);
+              }
+              if (!request.source) {
+                resolveCache[cacheId] = Object.assign({}, request, {
+                  parser: null,
+                  parserOptions: request.parser[NS + '/parser-options'],
+                  dependencies: null,
+                });
+              }
+              cb.apply(null, arguments);
+            });
+          };
+
+          var fromCache = function() {
+            var result = Object.assign({}, resolveCache[cacheId]);
+            result.dependencies = request.dependencies;
+            result.parser = compilation.compiler.parser;
+            if (!result.parser || !result.parser.parse) {
+              result.parser = params.normalModuleFactory.getParser(result.parserOptions);
+            }
+            return cb(null, result);
+          };
+
+          if (resolveCache[cacheId]) {
+            var userRequest = resolveCache[cacheId].userRequest;
+            if (fileTimestamps[userRequest]) {
+              return fromCache();
+            }
+            return fs.stat(userRequest, function(err) {
+              if (!err) {
+                return fromCache();
+              }
+
+              next();
+            });
+          }
+
+          next();
+        };
+      });
+    });
+  });
+};
+
+function BustModuleByDependencyPlugin() {}
+
+BustModuleByDependencyPlugin.prototype.apply = function(hardSource) {
+  new FileTimestampPlugin().apply(hardSource);
+
+  hardSource.plugin('dependency-bust', function() {
+    var moduleCache = this.getModuleCache();
+
+    // Invalidate modules that depend on a userRequest that is no longer
+    // valid.
+    var walkDependencyBlock = function(block, callback) {
+      block.dependencies.forEach(callback);
+      block.variables.forEach(function(variable) {
+        variable.dependencies.forEach(callback);
+      });
+      block.blocks.forEach(function(block) {
+        walkDependencyBlock(block, callback);
+      });
+    };
+    var fileTs = FileTimestampPlugin.getStamps(hardSource);
+    // Remove the out of date cache modules.
+    Object.keys(moduleCache).forEach(function(key) {
+      var cacheItem = moduleCache[key];
+      if (!cacheItem) {return;}
+      if (typeof cacheItem === 'string') {
+        cacheItem = JSON.parse(cacheItem);
+        moduleCache[key] = cacheItem;
+      }
+      var validDepends = true;
+      walkDependencyBlock(cacheItem, function(cacheDependency) {
+        validDepends = validDepends &&
+        hardSource.applyPluginsBailResult1('check-dependency', cacheDependency, cacheItem);
+      });
+      if (!validDepends) {
+        cacheItem.invalid = true;
+        moduleCache[key] = null;
+      }
+    });
+  });
+}
+
+function CheckDependencyCanResolvePlugin() {
+}
+
+CheckDependencyCanResolvePlugin.prototype.apply = function(hardSource) {
+  new FileTimestampPlugin().apply(hardSource);
+
+  var fileTs;
+
+  hardSource.plugin('before-dependency-bust', function(cb) {
+    fileTs = null;
+    cb();
+  });
+
+  hardSource.plugin('check-dependency', function(cacheDependency, cacheItem) {
+    if (!fileTs) {
+      fileTs = FileTimestampPlugin.getStamps(hardSource);
+    }
+
+    if (
+      cacheDependency.contextDependency ||
+      typeof cacheDependency.request === 'undefined'
+    ) {
+      return;
+    }
+
+    var resolveId = JSON.stringify(
+      [cacheItem.context, cacheDependency.request]
+    );
+    var resolveItem = resolveCache[resolveId];
+    if (
+      !resolveItem ||
+      !resolveItem.userRequest ||
+      fileTs[resolveItem.userRequest] === 0
+    ) {
+      return false;
+    }
+  });
+};
+
+function PreemptCompilerPlugin() {}
+
+PreemptCompilerPlugin.getCompilation = function(hardSource) {
+  return hardSource.__preemptCompilerPlugin.compilation;
+};
+
+PreemptCompilerPlugin.prototype.apply = function(hardSource) {
+  if (hardSource.__preemptCompilerPlugin) {return;}
+
+  var _this = hardSource.__preemptCompilerPlugin = this;
+
+  hardSource.plugin('before-module-bust', function(cb) {
+    var compiler = this.compiler;
+
+    Promise.resolve()
+    .then(function() {
+      // Ensure records have been read before we use the sub-compiler to
+      // invlidate packages before the normal compiler executes.
+      if (Object.keys((compiler.compiler || compiler).records).length === 0) {
+        return Promise.promisify(
+          (compiler.compiler || compiler).readRecords,
+          {context: (compiler.compiler || compiler)}
+        )();
+      }
+    })
+    .then(function() {
+      var _compiler = compiler.compiler || compiler;
+      // Create a childCompiler but set it up and run it like it is the original
+      // compiler except that it won't finalize the work ('after-compile' step
+      // that renders chunks).
+      var childCompiler = _compiler.createChildCompiler();
+      // Copy 'this-compilation' and 'make' as well as other plugins.
+      for(var name in _compiler._plugins) {
+        if(["compile", "emit", "after-emit", "invalid", "done"].indexOf(name) < 0)
+          childCompiler._plugins[name] = _compiler._plugins[name].slice();
+      }
+      // Use the parent's records.
+      childCompiler.records = (compiler.compiler || compiler).records;
+
+      var params = childCompiler.newCompilationParams();
+      childCompiler.applyPlugins("compile", params);
+
+      var compilation = _this.compilation = childCompiler.newCompilation(params);
+
+      // Run make and seal. This is enough to find out if any module should be
+      // invalidated due to some built state.
+      return Promise.promisify(childCompiler.applyPluginsParallel, {context: childCompiler})("make", compilation)
+      .then(function() {
+        return Promise.promisify(compilation.seal, {context: compilation})();
+      });
+    })
+    .then(function() {cb();}, cb);
+  });
+};
+
+function BustModulePlugin() {}
+
+BustModulePlugin.prototype.apply = function(hardSource) {
+  hardSource.plugin('module-bust', function() {
+    var moduleCache = hardSource.getModuleCache();
+
+    Object.keys(moduleCache).forEach(function(key) {
+      var cacheItem = moduleCache[key];
+      if (cacheItem) {
+        if (hardSource.applyPluginsBailResult1('check-module', cacheItem) === false) {
+          cacheItem.invalid = true;
+          moduleCache[module.request] = null;
+        }
+      }
+    });
+  });
+};
+
+function CheckModuleUsedFlagPlugin() {
+}
+
+CheckModuleUsedFlagPlugin.prototype.apply = function(hardSource) {
+  if (!NormalModule.prototype.isUsed) {return;}
+
+  new PreemptCompilerPlugin().apply(hardSource);
+
+  var _modules;
+  function modules() {
+    if (_modules) {return _modules;}
+
+    var compilation = PreemptCompilerPlugin.getCompilation(hardSource);
+    _modules = {};
+    compilation.modules.forEach(function(module) {
+      if (!(module instanceof HardModule)) {
+        return;
+      }
+
+      _modules[module.identifier()] = module;
+    });
+    return _modules;
+  }
+
+  hardSource.plugin('before-module-bust', function(cb) {
+    _modules = {};
+    cb();
+  });
+
+  hardSource.plugin('check-module', function(cacheItem) {
+    var module = modules()[cacheItem.identifier];
+    if (!module) {return;}
+    // Check with the module in the sub-compiler and invalidate if cached one
+    // used and usedExports do not match their new values due to a dependent
+    // module changing what it uses.
+    if (
+      !lodash.isEqual(cacheItem.used, module.used) ||
+      !lodash.isEqual(cacheItem.usedExports, module.usedExports)
+    ) {
+      return false;
+    }
+  });
+};
+
+function HardSourceWebpackPlugin(options) {
+  Tapable.call(this);
+  this.options = options;
+
+  new DependencySerializePlugin().apply(this);
+  new DependencyThawPlugin().apply(this);
+  new HarmonyDependencySerializePlugin().apply(this);
+  new HarmonyDependencyThawPlugin().apply(this);
+
+  new ResolveCachePlugin().apply(this);
+  new BustModuleByDependencyPlugin().apply(this);
+  new CheckDependencyCanResolvePlugin().apply(this);
+  new BustModulePlugin().apply(this);
+  new CheckModuleUsedFlagPlugin().apply(this);
+
+  new ModuleSerializePlugin().apply(this);
+}
+
+HardSourceWebpackPlugin.prototype = Object.create(Tapable.prototype);
+HardSourceWebpackPlugin.prototype.constructor = HardSourceWebpackPlugin;
 
 HardSourceWebpackPlugin.prototype.getPath = function(dirName, suffix) {
   var confighashIndex = dirName.search(/\[confighash\]/);
@@ -265,8 +799,37 @@ HardSourceWebpackPlugin.prototype.getCachePath = function(suffix) {
   return this.getPath(this.options.cacheDirectory, suffix);
 };
 
+HardSourceWebpackPlugin.prototype.applyPluginsPromise = function(name, args) {
+  return Promise.promisify(this.applyPluginsAsync).apply(this, arguments);
+};
+
+HardSourceWebpackPlugin.prototype.freeze = function(supertype, object) {
+  return this.applyPluginsWaterfall('freeze-' + supertype, null, object);
+};
+
+HardSourceWebpackPlugin.prototype.thaw = function(supertype, object) {
+  return this.applyPluginsWaterfall('thaw-' + supertype, null, object);
+};
+
+HardSourceWebpackPlugin.prototype.valid = function(supertype, object) {
+  return this.applyPluginsBailResult1('valid-' + supertype, object);
+};
+
+HardSourceWebpackPlugin.prototype.getModuleCache = function() {
+  return this.moduleCache;
+};
+
+HardSourceWebpackPlugin.prototype.getAssetCache = function() {
+  return this.assetCache;
+};
+
+HardSourceWebpackPlugin.prototype.getDataCache = function() {
+  return this.dataCache;
+};
+
 module.exports = HardSourceWebpackPlugin;
 HardSourceWebpackPlugin.prototype.apply = function(compiler) {
+  var _this = this;
   var options = this.options;
   var active = true;
   if (!options.cacheDirectory) {
@@ -315,10 +878,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var cacheAssetDirPath = path.join(cacheDirPath, 'assets');
   var resolveCachePath = path.join(cacheDirPath, 'resolve.json');
 
-  var resolveCache = {};
-  var moduleCache = {};
-  var assetCache = {};
-  var dataCache = {};
+  var moduleCache = this.moduleCache = {};
+  var assetCache = this.assetCache = {};
+  var dataCache = this.dataCache = {};
   var currentStamp = '';
 
   var fileTimestamps = {};
@@ -330,7 +892,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var dataCacheSerializer = this.dataCacheSerializer =
     new LevelDbSerializer({cacheDirPath: path.join(cacheDirPath, 'data')});
 
-  var _this = this;
+  _this.compiler = compiler;
+
+  _this.applyPlugins('compiler', compiler);
 
   compiler.plugin('after-plugins', function() {
     if (
@@ -381,21 +945,16 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         }
 
         // Reset the cache, we can't use it do to an environment change.
-        resolveCache = {};
-        moduleCache = {};
-        assetCache = {};
-        dataCache = {};
-        fileTimestamps = {};
+        _this.applyPlugins('reset');
+        moduleCache = this.moduleCache = {};
+        assetCache = this.assetCache = {};
+        dataCache = this.dataCache = {};
         return;
       }
 
       if (Object.keys(moduleCache).length) {return Promise.resolve();}
 
       return Promise.all([
-        fsReadFile(resolveCachePath, 'utf8')
-        .then(JSON.parse)
-        .then(function(_resolveCache) {resolveCache = _resolveCache}),
-
         assetCacheSerializer.read()
         .then(function(_assetCache) {assetCache = _assetCache;}),
 
@@ -410,6 +969,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
               dataCache[key] = JSON.parse(dataCache[key]);
             }
           });
+
+          _this.applyPlugins('thaw-compilation-data', dataCache);
         }),
       ])
       .then(function() {
@@ -422,73 +983,20 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   compiler.plugin(['watch-run', 'run'], function(compiler, cb) {
     if (!active) {return cb();}
 
-    if(!dataCache.fileDependencies) return cb();
-    // var fs = compiler.inputFileSystem;
-    var fileTs = compiler.fileTimestamps = fileTimestamps = {};
-
-    return Promise.all(dataCache.fileDependencies.map(function(file) {
-      return fsStat(file)
-      .then(function(stat) {
-        fileTs[file] = stat.mtime || Infinity;
-      }, function(err) {
-        fileTs[file] = 0;
-
-        if (err.code === "ENOENT") {return;}
-        throw err;
-      });
-    }))
-    .then(function() {
-      // Invalidate modules that depend on a userRequest that is no longer
-      // valid.
-      var walkDependencyBlock = function(block, callback) {
-        block.dependencies.forEach(callback);
-        block.variables.forEach(function(variable) {
-          variable.dependencies.forEach(callback);
-        });
-        block.blocks.forEach(function(block) {
-          walkDependencyBlock(block, callback);
-        });
-      };
-      // Remove the out of date cache modules.
-      Object.keys(moduleCache).forEach(function(key) {
-        var cacheItem = moduleCache[key];
-        if (!cacheItem) {return;}
-        if (typeof cacheItem === 'string') {
-          cacheItem = JSON.parse(cacheItem);
-          moduleCache[key] = cacheItem;
-        }
-        var validDepends = true;
-        walkDependencyBlock(cacheItem, function(cacheDependency) {
-          if (
-            !cacheDependency ||
-            cacheDependency.contextDependency ||
-            typeof cacheDependency.request === 'undefined'
-          ) {
-            return;
-          }
-
-          var resolveId = JSON.stringify(
-            [cacheItem.context, cacheDependency.request]
-          );
-          var resolveItem = resolveCache[resolveId];
-          validDepends = validDepends &&
-            resolveItem &&
-            resolveItem.userRequest &&
-            fileTs[resolveItem.userRequest] !== 0;
-        });
-        if (!validDepends) {
-          cacheItem.invalid = true;
-          moduleCache[key] = null;
-        }
-      });
-    })
+    return Promise.resolve()
+    .then(function() {return _this.applyPluginsPromise('before-dependency-bust');})
+    .then(function() {return _this.applyPlugins('dependency-bust');})
+    .then(function() {return _this.applyPluginsPromise('after-dependency-bust');})
+    .then(function() {return _this.applyPluginsPromise('before-module-bust');})
+    .then(function() {return _this.applyPlugins('module-bust');})
+    .then(function() {return _this.applyPluginsPromise('after-module-bust');})
     .then(function() {cb();}, cb);
   });
 
   compiler.plugin('compilation', function(compilation, params) {
     if (!active) {return;}
 
-    compilation.fileTimestamps = fileTimestamps;
+    compilation.__hardSource = _this;
 
     compilation.dependencyFactories.set(HardModuleDependency, params.normalModuleFactory);
     compilation.dependencyTemplates.set(HardModuleDependency, new NullDependencyTemplate);
@@ -534,63 +1042,6 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         needAdditionalPass = false;
         return true;
       }
-    });
-
-    // Webpack 2 can use different parsers based on config rule sets.
-    params.normalModuleFactory.plugin('parser', function(parser, options) {
-      // Store the options somewhere that can not conflict with another plugin
-      // on the parser so we can look it up and store those options with a
-      // cached module resolution.
-      parser[NS + '/parser-options'] = options;
-    });
-
-    params.normalModuleFactory.plugin('resolver', function(fn) {
-      return function(request, cb) {
-        var cacheId = JSON.stringify([request.context, request.request]);
-
-        var next = function() {
-          var originalRequest = request;
-          return fn.call(null, request, function(err, request) {
-            if (err) {
-              return cb(err);
-            }
-            if (!request.source) {
-              resolveCache[cacheId] = Object.assign({}, request, {
-                parser: null,
-                parserOptions: request.parser[NS + '/parser-options'],
-                dependencies: null,
-              });
-            }
-            cb.apply(null, arguments);
-          });
-        };
-
-        var fromCache = function() {
-          var result = Object.assign({}, resolveCache[cacheId]);
-          result.dependencies = request.dependencies;
-          result.parser = compilation.compiler.parser;
-          if (!result.parser || !result.parser.parse) {
-            result.parser = params.normalModuleFactory.getParser(result.parserOptions);
-          }
-          return cb(null, result);
-        };
-
-        if (resolveCache[cacheId]) {
-          var userRequest = resolveCache[cacheId].userRequest;
-          if (fileTimestamps[userRequest]) {
-            return fromCache();
-          }
-          return fs.stat(userRequest, function(err) {
-            if (!err) {
-              return fromCache();
-            }
-
-            next();
-          });
-        }
-
-        next();
-      };
     });
 
     params.normalModuleFactory.plugin('resolver', function(fn) {
@@ -648,7 +1099,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
 
     var startCacheTime = Date.now();
 
-    var devtoolOptions = makeDevtoolOptions(compiler.options);
+    var devtoolOptions = _this.devtoolOptions = makeDevtoolOptions(compiler.options);
 
     // fs.writeFileSync(
     //   path.join(cacheDirPath, 'file-dependencies.json'),
@@ -660,46 +1111,17 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     var dataOps = [];
     var assetOps = [];
 
-    var fileDependenciesDiff = lodash.difference(compilation.fileDependencies, dataCache.fileDependencies || []);
-    if (fileDependenciesDiff.length) {
-      dataCache.fileDependencies = (dataCache.fileDependencies || [])
-      .concat(fileDependenciesDiff);
+    var dataOut = {};
+    _this.applyPlugins('freeze-compilation-data', dataOut, compilation);
 
+    Object.keys(dataOut).forEach(function(key) {
+      var data = dataOut[key];
+      dataCache[key] = data;
       dataOps.push({
-        key: 'fileDependencies',
-        value: JSON.stringify(dataCache.fileDependencies),
+        key: key,
+        value: JSON.stringify(data),
       });
-    }
-
-    // moduleCache.fileDependencies = compilation.fileDependencies;
-    // moduleOps.push({
-    //   type: 'put',
-    //   key: 'fileDependencies',
-    //   // value: JSON.stringify(compilation.fileDependencies),
-    //   value: moduleCache.fileDependencies,
-    // });
-
-    // mkdirp.sync(cacheAssetDirPath);
-
-    function walkCompilations(compilation, fn) {
-      fn(compilation);
-      compilation.children.forEach(function(compilation) {
-        walkCompilations(compilation, fn);
-      });
-    }
-
-    function serializeError(error) {
-      var serialized = {
-        message: error.message,
-      };
-      if (error.origin) {
-        serialized.origin = serializeDependencies([error.origin])[0];
-      }
-      if (error.dependencies) {
-        serialized.dependencies = serializeDependencies(error.dependencies);
-      }
-      return serialized;
-    }
+    });
 
     compilation.modules.forEach(function(module) {
       var identifierPrefix = cachePrefix(compilation);
@@ -707,67 +1129,10 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         return;
       }
       var identifier = identifierPrefix + module.identifier();
-      var existingCacheItem = moduleCache[identifier];
 
-      if (
-        module.request &&
-        module.cacheable &&
-        !(module instanceof HardModule) &&
-        (module instanceof NormalModule) &&
-        (
-          existingCacheItem &&
-          module.buildTimestamp > existingCacheItem.buildTimestamp ||
-          !existingCacheItem
-        )
-      ) {
-        var source = module.source(
-          compilation.dependencyTemplates,
-          compilation.moduleTemplate.outputOptions,
-          compilation.moduleTemplate.requestShortener
-        );
-        var assets = Object.keys(module.assets || {}).map(function(key) {
-          return {
-            key: requestHash(key),
-            value: module.assets[key].source(),
-          };
-        });
-        moduleCache[identifier] = {
-          moduleId: module.id,
-          context: module.context,
-          request: module.request,
-          userRequest: module.userRequest,
-          rawRequest: module.rawRequest,
-          resource: module.resource,
-          loaders: module.loaders,
-          identifier: module.identifier(),
-          // libIdent: module.libIdent &&
-          // module.libIdent({context: compiler.options.context}),
-          assets: Object.keys(module.assets || {}),
-          buildTimestamp: module.buildTimestamp,
-          strict: module.strict,
-          meta: module.meta,
-          used: module.used,
-          usedExports: module.usedExports,
-
-          rawSource: module._source ? module._source.source() : null,
-          source: source.source(),
-          map: devtoolOptions && source.map(devtoolOptions),
-          // Some plugins (e.g. UglifyJs) set useSourceMap on a module. If that
-          // option is set we should always store some source map info and
-          // separating it from the normal devtool options may be necessary.
-          baseMap: module.useSourceMap && source.map(),
-          hashContent: serializeHashContent(module),
-
-          dependencies: serializeDependencies(module.dependencies),
-          variables: serializeVariables(module.variables),
-          blocks: serializeBlocks(module.blocks),
-
-          fileDependencies: module.fileDependencies,
-          contextDependencies: module.contextDependencies,
-
-          errors: module.errors.map(serializeError),
-          warnings: module.warnings.map(serializeError),
-        };
+      var frozenModule = this.applyPluginsWaterfall('freeze-module', null, module, compilation);
+      if (frozenModule) {
+        moduleCache[identifier] = frozenModule;
 
         // Custom plugin handling for common plugins.
         // This will be moved in a pluginified HardSourcePlugin.
@@ -782,18 +1147,30 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
 
         moduleOps.push({
           key: identifier,
-          value: JSON.stringify(moduleCache[identifier]),
+          value: JSON.stringify(frozenModule),
         });
 
-        if (assets.length) {
-          assetOps = assetOps.concat(assets);
+        if (module.assets) {
+          Object.keys(module.assets).forEach(function(key) {
+            var asset = module.assets[key];
+            var frozen = this.applyPluginsWaterfall('freeze-asset', null, asset, module);
+            if (frozen) {
+              var frozenKey = requestHash(key);
+
+              assetCache[frozenKey] = frozen;
+
+              assetOps.push({
+                key: frozenKey,
+                value: frozen,
+              });
+            }
+          }, this);
         }
       }
-    });
+    }, _this);
 
     Promise.all([
       fsWriteFile(path.join(cacheDirPath, 'stamp'), currentStamp, 'utf8'),
-      fsWriteFile(resolveCachePath, JSON.stringify(resolveCache), 'utf8'),
       assetCacheSerializer.write(assetOps),
       moduleCacheSerializer.write(moduleOps),
       dataCacheSerializer.write(dataOps),

--- a/lib/cache-serializers.js
+++ b/lib/cache-serializers.js
@@ -9,6 +9,7 @@ var fsReadFile = Promise.promisify(fs.readFile, {context: fs});
 var fsReaddir = Promise.promisify(fs.readdir, {context: fs});
 var fsStat = Promise.promisify(fs.stat, {context: fs});
 var fsWriteFile = Promise.promisify(fs.writeFile, {context: fs});
+var fsUnlink = Promise.promisify(fs.unlink, {context: fs});
 
 exports.FileSerializer = FileSerializer;
 exports.LevelDbSerializer = LevelDbSerializer;
@@ -33,7 +34,12 @@ FileSerializer.prototype.write = function(assetOps) {
   var cacheAssetDirPath = this.path;
   return Promise.all(assetOps.map(function(asset) {
     var assetPath = path.join(cacheAssetDirPath, asset.key);
-    return fsWriteFile(assetPath, asset.value);
+    if (asset.value) {
+      return fsWriteFile(assetPath, asset.value);
+    }
+    else {
+      return fsUnlink(assetPath);
+    }
   }));
 };
 
@@ -70,11 +76,16 @@ LevelDbSerializer.prototype.write = function(moduleOps) {
   var ops = moduleOps;
 
   if (ops.length === 0) {
-    return;
+    return Promise.resolve();
   }
 
   for (var i = 0; i < ops.length; i++) {
-    ops.type = 'put';
+    if (ops.value) {
+      ops.type = 'put';
+    }
+    else {
+      ops.type = 'delete';
+    }
   }
 
   var cachePath = this.path;

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -98,38 +98,7 @@ HardModule.prototype.libIdent = function(options) {
 
 function deserializeDependencies(deps, parent) {
   return deps.map(function(req) {
-    if (req.contextDependency) {
-      var dep = new HardContextDependency(req.request, req.recursive, req.regExp ? new RegExp(req.regExp) : null);
-      dep.critical = req.contextCritical;
-      dep.loc = req.loc;
-      return dep;
-    }
-    if (req.constDependency) {
-      return new HardNullDependency();
-    }
-    if (req.harmonyExport) {
-      return new HardHarmonyExportDependency(parent, req.harmonyId, req.harmonyName, req.harmonyPrecedence);
-    }
-    if (req.harmonyImport) {
-      if (this.state.imports[req.request]) {
-        return this.state.imports[req.request];
-      }
-      return this.state.imports[req.request] = new HardHarmonyImportDependency(req.request);
-    }
-    if (req.harmonyImportSpecifier) {
-      var dep = new HardHarmonyImportSpecifierDependency(this.state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
-      dep.loc = req.loc;
-      return dep;
-    }
-    if (req.harmonyExportImportedSpecifier) {
-      if (!this.state.imports[req.harmonyRequest]) {
-        this.state.imports[req.harmonyRequest] = new HardHarmonyImportDependency(req.harmonyRequest);
-      }
-      return new HardHarmonyExportImportedSpecifierDependency(parent, this.state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
-    }
-    var dep = new HardModuleDependency(req.request);
-    dep.loc = req.loc;
-    return dep;
+    return this.__hardSource.applyPluginsWaterfall('thaw-dependency', null, req, this.state);
   }, this);
 }
 function deserializeVariables(vars, parent) {
@@ -174,7 +143,10 @@ HardModule.prototype.build = function build(options, compilation, resolver, fs, 
   // Rendered source used in built output.
   this._renderedSource = new HardSource(this.cacheItem);
 
-  var state = {state: {imports: {}}};
+  var state = {
+    __hardSource: compilation.__hardSource,
+    state: {imports: {}},
+  };
   this.dependencies = deserializeDependencies.call(state, this.cacheItem.dependencies, this);
   this.variables = deserializeVariables.call(state, this.cacheItem.variables, this);
   this.warnings = this.cacheItem.warnings.map(deserializeError(ModuleWarning, state), this);

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -97,25 +97,29 @@ HardModule.prototype.libIdent = function(options) {
 // };
 
 function deserializeDependencies(deps, parent) {
+  var _this = this;
+  _this.state.parent = parent;
   return deps.map(function(req) {
-    return this.__hardSource.applyPluginsWaterfall('thaw-dependency', null, req, this.state);
-  }, this);
+    return _this.__hardSource.applyPluginsWaterfall('thaw-dependency', null, req, _this.state);
+  }, _this);
 }
 function deserializeVariables(vars, parent) {
+  var _this = this;
   return vars.map(function(req) {
-    return new DependenciesBlockVariable(req.name, req.expression, deserializeDependencies.call(this, req.dependencies, parent));
-  }, this);
+    return new DependenciesBlockVariable(req.name, req.expression, deserializeDependencies.call(_this, req.dependencies, parent));
+  }, _this);
 }
 function deserializeBlocks(blocks, parent) {
+  var _this = this;
   blocks.map(function(req) {
     if (req.async) {
       var block = new AsyncDependenciesBlock(req.name, parent);
-      block.dependencies = deserializeDependencies.call(this, req.dependencies, parent);
-      block.variables = deserializeVariables.call(this, req.variables, parent);
-      deserializeBlocks(req.blocks, block);
+      block.dependencies = deserializeDependencies.call(_this, req.dependencies, parent);
+      block.variables = deserializeVariables.call(_this, req.variables, parent);
+      deserializeBlocks.call(_this, req.blocks, block);
       return block;
     }
-  }, this)
+  })
   .filter(Boolean)
   .forEach(function(block) {
     parent.addBlock(block);

--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
   "dependencies": {
     "bluebird": "^3.0.0",
     "env-hash": "^1.0.1",
+    "html-uglify": "^1.2.1",
     "level": "^1.4.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
     "source-list-map": "^0.1.6",
     "source-map": "^0.5.6",
-    "webpack-sources": "^0.1.2",
-    "webpack-core": "~0.6.0"
+    "tapable": "^0.2.4",
+    "webpack-core": "~0.6.0",
+    "webpack-sources": "^0.1.2"
   }
 }

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -110,7 +110,7 @@ exports.itCompilesTwice = function(fixturePath, compileOptions) {
   });
 
   it('builds identical ' + fixturePath + ' fixture', function() {
-    this.timeout(10000);
+    this.timeout(20000);
     return exports.compileTwiceEqual(fixturePath, compileOptions);
   });
 };


### PR DESCRIPTION
**This is a Work In Progress.**

The HardSource plugin naturally lends itself to webpack users wanting to have their myriad plugins integrate with it so that the benefits of disk caching can go beyond webpack's core features.

This change introduces plugin points for a series of parts of HardSource and reimplements much of HardSource to use and provide those plugin points.

The plugin points are:
- `before-dependency-bust`
- `dependency-bust`
- `after-dependency-bust`
- `before-module-bust`
- `module-bust`
- `after-module-bust`
- `freeze-compilation-data`
- `freeze-dependency`
- `freeze-asset`
- `freeze-module`
- `thaw-compilcation-data`
- `thaw-dependency`

This PR won't expose plugin points to do everything you may want yet. It focuses on HardSource's current features and what have been discovered over its development that could use assistance to do its job instead of exposing a full plugin platform for caching as much of webpack as possible. That is a goal for HardSource but not for this PR.

The plugins are used in this PR to implement some of HardSource's workflow. This is done in part for supporting webpack 1 and 2 and to support the latter, enabling relevant plugins to HardSource that webpack 1 doesn't need.

HardSource's internal plugins are:
- `BustModuleByDependencyPlugin`
- `BustModulePlugin`
- `CheckDependencyCanResolvePlugin`
- `CheckModuleUsedFlagPlugin`
- `DependencySerializePlugin`
- `DependencyThawPlugin`
- `FileTimestampPlugin`
- `HarmonyDependencySerializePlugin`
- `HarmonyDependencyThawPlugin`
- `ModuleSerializePlugin`
- `PreemptCompilePlugin`
- `ResolveCachePlugin`

`FileTimestampPlugin` and `PreemptCompilePlugin` are **"shared"** plugins. They are built not to do direct cache work but to generalize a large work load that multiple other plugins depend on to do direct cache work.

TK talk more on FileTimestampPlugin
- [ ] Investigate plugin points for thawing assets and modules
- [ ] Further organize "common" and "harmony" plugins
- [ ] ...
