### PR TITLE
Replace pre-emptive compiler with additional pass

### DIFF
--- a/tests/fixtures/plugin-hmr-es2015/fib.js
+++ b/tests/fixtures/plugin-hmr-es2015/fib.js
@@ -1,0 +1,5 @@
+export function fib(n) {
+  return n + (n > 0 ? n - 2 : 0);
+};
+
+export var key = 'fib';

--- a/tests/fixtures/plugin-hmr-es2015/index.js
+++ b/tests/fixtures/plugin-hmr-es2015/index.js
@@ -1,0 +1,2 @@
+import {fib} from './fib';
+console.log(fib(3));

--- a/tests/fixtures/plugin-hmr-es2015/webpack.config.js
+++ b/tests/fixtures/plugin-hmr-es2015/webpack.config.js
@@ -1,0 +1,21 @@
+var HotModuleReplacementPlugin = require('webpack').HotModuleReplacementPlugin;
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HotModuleReplacementPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: __dirname + '/tmp/cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/plugin-hmr/fib/index.js
+++ b/tests/fixtures/plugin-hmr/fib/index.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 2 : 0);
+};

--- a/tests/fixtures/plugin-hmr/index.js
+++ b/tests/fixtures/plugin-hmr/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/plugin-hmr/webpack.config.js
+++ b/tests/fixtures/plugin-hmr/webpack.config.js
@@ -1,0 +1,21 @@
+var HotModuleReplacementPlugin = require('webpack').HotModuleReplacementPlugin;
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HotModuleReplacementPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: __dirname + '/tmp/cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/plugins-webpack-2.js
+++ b/tests/plugins-webpack-2.js
@@ -22,4 +22,24 @@ describeWP2('plugin webpack 2 use - builds changes', function() {
     expect(output.run2['main.js'].toString()).to.contain('t.a');
   });
 
+  itCompilesChange('plugin-hmr-es2015', {
+    'index.js': [
+      'import {key} from \'./fib\';',
+      'console.log(key);',
+    ].join('\n'),
+  }, {
+    'index.js': [
+      'import {fib} from \'./fib\';',
+      'console.log(fib(3));',
+    ].join('\n'),
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/return key/);
+    expect(output.run1['main.js'].toString()).to.match(/\/* key/);
+    expect(output.run2['main.js'].toString()).to.match(/exports\["a"\]/);
+    expect(output.run2['main.js'].toString()).to.match(/\/* fib/);
+    expect(Object.keys(output.run2).filter(function(key) {
+      return /\.hot-update\.json/.test(key);
+    })).to.length.of(2);
+  });
+
 });

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 
 var itCompilesTwice = require('./util').itCompilesTwice;
+var itCompilesChange = require('./util').itCompilesChange;
 
 describe('plugin webpack use', function() {
 
@@ -13,5 +14,31 @@ describe('plugin webpack use', function() {
   itCompilesTwice('plugin-extract-text-uglify-eval-source-map');
   itCompilesTwice('plugin-extract-text-html-uglify');
   itCompilesTwice('plugin-isomorphic-tools');
+
+});
+
+describe('plugin webpack use - builds changes', function() {
+
+  itCompilesChange('plugin-hmr', {
+    'fib.js': [
+      'module.exports = function(n) {',
+      '  return n + (n > 0 ? n - 1 : 0);',
+      '};',
+    ].join('\n'),
+    'fib/index.js': null,
+  }, {
+    'fib.js': null,
+    'fib/index.js': [
+      'module.exports = function(n) {',
+      '  return n + (n > 0 ? n - 2 : 0);',
+      '};',
+    ].join('\n'),
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/n - 1/);
+    expect(output.run2['main.js'].toString()).to.match(/n - 2/);
+    expect(Object.keys(output.run2).filter(function(key) {
+      return /\.hot-update\.json/.test(key);
+    })).to.length.of(1);
+  });
 
 });


### PR DESCRIPTION
Fixes #27

webpack 2 can run as many compile passes as needed by responding to a
new plugin point called need-additional-pass. The way this PR supports
accurate used modules is through using additional passes as necessary.
This has the benefit of only using one pass when only one is needed and
working with other plugins like HMR that the pre-emptive step was
breaking in cases.