### PR TITLE
Cache module warnings & errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/fixtures/*/tmp

--- a/index.js
+++ b/index.js
@@ -581,8 +581,17 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       });
     }
 
-    function getMessage(obj) {
-      return obj.message;
+    function serializeError(error) {
+      var serialized = {
+        message: error.message,
+      };
+      if (error.origin) {
+        serialized.origin = serializeDependencies([error.origin])[0];
+      }
+      if (error.dependencies) {
+        serialized.dependencies = serializeDependencies(error.dependencies);
+      }
+      return serialized;
     }
 
     compilation.modules.forEach(function(module, cb) {
@@ -643,8 +652,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           fileDependencies: module.fileDependencies,
           contextDependencies: module.contextDependencies,
 
-          errors: module.errors.map(getMessage),
-          warnings: module.warnings.map(getMessage),
+          errors: module.errors.map(serializeError),
+          warnings: module.warnings.map(serializeError),
         };
 
         moduleOps.push({

--- a/index.js
+++ b/index.js
@@ -596,7 +596,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       ) {
         var source = module.source(
           compilation.dependencyTemplates,
-          compilation.moduleTemplate.outputOptions, 
+          compilation.moduleTemplate.outputOptions,
           compilation.moduleTemplate.requestShortener
         );
         var assets = Object.keys(module.assets || {}).map(function(key) {

--- a/index.js
+++ b/index.js
@@ -581,6 +581,10 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       });
     }
 
+    function getMessage(obj) {
+      return obj.message;
+    }
+
     compilation.modules.forEach(function(module, cb) {
       var existingCacheItem = moduleCache[module.identifier()];
       if (
@@ -638,6 +642,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
 
           fileDependencies: module.fileDependencies,
           contextDependencies: module.contextDependencies,
+
+          errors: module.errors.map(getMessage),
+          warnings: module.warnings.map(getMessage),
         };
 
         moduleOps.push({

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -121,7 +121,9 @@ function deserializeDependencies(deps, parent) {
     if (req.harmonyExportImportedSpecifier) {
       return new HardHarmonyExportImportedSpecifierDependency(parent, this.state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
     }
-    return new HardModuleDependency(req.request);
+    var dep = new HardModuleDependency(req.request);
+    dep.loc = req.loc;
+    return dep;
   }, this);
 }
 function deserializeVariables(vars, parent) {
@@ -145,12 +147,17 @@ function deserializeBlocks(blocks, parent) {
   });
 }
 
-function makeWarning(message) {
-  return new ModuleWarning(this, message);
-}
-
-function makeError(message) {
-  return new ModuleError(this, message);
+function deserializeError(ErrorClass, state) {
+  return function(serialized) {
+    var err = new ErrorClass(this, serialized.message);
+    if (serialized.origin) {
+      err.origin = deserializeDependencies.call(state, [serialized.origin], this)[0];
+    }
+    if (serialized.dependencies) {
+      err.dependencies = deserializeDependencies.call(state, serialized.dependencies, this);
+    }
+    return err;
+  };
 }
 
 HardModule.prototype.build = function build(options, compilation, resolver, fs, callback) {
@@ -164,8 +171,8 @@ HardModule.prototype.build = function build(options, compilation, resolver, fs, 
   var state = {state: {imports: {}}};
   this.dependencies = deserializeDependencies.call(state, this.cacheItem.dependencies, this);
   this.variables = deserializeVariables.call(state, this.cacheItem.variables, this);
-  this.warnings = this.cacheItem.warnings.map(makeWarning, this);
-  this.errors = this.cacheItem.errors.map(makeError, this);
+  this.warnings = this.cacheItem.warnings.map(deserializeError(ModuleWarning, state), this);
+  this.errors = this.cacheItem.errors.map(deserializeError(ModuleError, state), this);
   deserializeBlocks.call(state, this.cacheItem.blocks, this);
 
   var cacheItem = this.cacheItem;

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -4,6 +4,9 @@ var AsyncDependenciesBlock = require('webpack/lib/AsyncDependenciesBlock');
 var DependenciesBlockVariable = require('webpack/lib/DependenciesBlockVariable');
 var RawModule = require('webpack/lib/RawModule');
 
+var ModuleError = require('webpack-core/lib/ModuleError');
+var ModuleWarning = require('webpack-core/lib/ModuleWarning');
+
 var RawSource = require('webpack-sources').RawSource;
 
 var HardModuleDependency = require('./dependencies').HardModuleDependency;
@@ -142,6 +145,14 @@ function deserializeBlocks(blocks, parent) {
   });
 }
 
+function makeWarning(message) {
+  return new ModuleWarning(this, message);
+}
+
+function makeError(message) {
+  return new ModuleError(this, message);
+}
+
 HardModule.prototype.build = function build(options, compilation, resolver, fs, callback) {
   // Non-rendered source used by Stats.
   if (this.cacheItem.rawSource) {
@@ -153,6 +164,8 @@ HardModule.prototype.build = function build(options, compilation, resolver, fs, 
   var state = {state: {imports: {}}};
   this.dependencies = deserializeDependencies.call(state, this.cacheItem.dependencies, this);
   this.variables = deserializeVariables.call(state, this.cacheItem.variables, this);
+  this.warnings = this.cacheItem.warnings.map(makeWarning, this);
+  this.errors = this.cacheItem.errors.map(makeError, this);
   deserializeBlocks.call(state, this.cacheItem.blocks, this);
 
   var cacheItem = this.cacheItem;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mkdirp": "^0.5.1",
     "source-list-map": "^0.1.6",
     "source-map": "^0.5.6",
-    "webpack-sources": "^0.1.2"
+    "webpack-sources": "^0.1.2",
+    "webpack-core": "~0.6.0"
   }
 }

--- a/tests/fixtures/loader-warning/index.js
+++ b/tests/fixtures/loader-warning/index.js
@@ -1,0 +1,2 @@
+// fake content
+require("./module");

--- a/tests/fixtures/loader-warning/loader.js
+++ b/tests/fixtures/loader-warning/loader.js
@@ -1,0 +1,7 @@
+module.exports = function(source) {
+  var done = this.async();
+  this.cacheable();
+  this.emitWarning("This is a test warning");
+  this.emitError("This is a test error");
+  done(null, source);
+};

--- a/tests/fixtures/loader-warning/webpack.config.js
+++ b/tests/fixtures/loader-warning/webpack.config.js
@@ -1,0 +1,24 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loader: __dirname + "/loader",
+      },
+    ],
+  },
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+    }),
+  ],
+};

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -29,8 +29,8 @@ describe('loader webpack warnings & errors', function() {
         expect(runs[0].out).to.eql(runs[1].out);
         expect(runs[0].warnings.length).to.greaterThan(0);
         expect(runs[0].errors.length).to.greaterThan(0);
-        expect(runs[0].warnings).to.eql(runs[1].warnings);
-        expect(runs[0].errors).to.eql(runs[1].errors);
+        expect(runs[1].warnings).to.eql(runs[0].warnings);
+        expect(runs[1].errors).to.eql(runs[0].errors);
       });
   });
 

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -22,9 +22,9 @@ describe('loader webpack warnings & errors', function() {
 
   it('should cache errors & warnings from loader', function() {
     this.timeout(10000);
-    return compile(fixturePath, true)
+    return compile(fixturePath, {exportStats: true})
       .then(function(run1) {
-        return Promise.all([run1, compile(fixturePath, true)])
+        return Promise.all([run1, compile(fixturePath, {exportStats: true})])
       }).then(function(runs) {
         expect(runs[0].out).to.eql(runs[1].out);
         expect(runs[0].warnings.length).to.greaterThan(0);

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -1,10 +1,35 @@
 var expect = require('chai').expect;
 
-var itCompilesTwice = require('./util').itCompilesTwice;
+var util = require('./util');
+var itCompilesTwice = util.itCompilesTwice;
+var clean = util.clean;
+var compile = util.compile;
 
 describe('loader webpack use', function() {
 
   itCompilesTwice('loader-css');
   itCompilesTwice('loader-file');
+
+});
+
+describe('loader webpack warnings & errors', function() {
+
+  var fixturePath = 'loader-warning';
+
+  before(function() {
+    return clean(fixturePath);
+  });
+
+  it('should cache errors & warnings from loader', function() {
+    this.timeout(10000);
+    return compile(fixturePath, true)
+      .then(function(run1) {
+        return Promise.all([run1, compile(fixturePath, true)])
+      }).then(function(runs) {
+        expect(runs[0].out).to.eql(runs[1].out);
+        expect(runs[0].warnings).to.eql(runs[1].warnings);
+        expect(runs[0].errors).to.eql(runs[1].errors);
+      });
+  });
 
 });

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -27,6 +27,8 @@ describe('loader webpack warnings & errors', function() {
         return Promise.all([run1, compile(fixturePath, true)])
       }).then(function(runs) {
         expect(runs[0].out).to.eql(runs[1].out);
+        expect(runs[0].warnings.length).to.greaterThan(0);
+        expect(runs[0].errors.length).to.greaterThan(0);
         expect(runs[0].warnings).to.eql(runs[1].warnings);
         expect(runs[0].errors).to.eql(runs[1].errors);
       });

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -26,7 +26,7 @@ function callModule(fn, filename) {
   return module.exports;
 }
 
-exports.compile = function(fixturePath, exportStats) {
+exports.compile = function(fixturePath, options) {
   var configPath = path.join(__dirname, '..', 'fixtures', fixturePath, 'webpack.config.js');
   var compiler = webpack(callModule(vm.runInThisContext(wrapModule(fs.readFileSync(configPath, 'utf8')), {filename: configPath}), configPath));
   var outputfs = compiler.outputFileSystem = new MemoryFS();
@@ -74,7 +74,7 @@ exports.compile = function(fixturePath, exportStats) {
       return carry;
     }, {})
     .then(function(carry) {
-      if (exportStats) {
+      if (options && options.exportStats) {
         var statsJson = stats.toJson({
           errors: true,
           warnings: true,


### PR DESCRIPTION
This PR introduces to cache module build warnings & errors.
This feature is extremely useful for linting loaders (tslint-loader, eslint-loader, ...)

Closes #32 

- [x] add failing test
- [x] fix failing test