### PR TITLE
Support webpack 2's move to multiple parsers

### DIFF
--- a/tests/fixtures/plugin-extract-text/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text/webpack.config.js
@@ -35,6 +35,9 @@ module.exports = {
     new ExtractTextPlugin('style.css'),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
     }),
   ],
 };


### PR DESCRIPTION
Fix #34

- Store the parser's options in resolutions so that they can be created
  when thawing the cache.
- Add custom handling for change to extract-text beta version