### PR TITLE
Flatten `loc` dependency field

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,14 @@ try {
 }
 catch (_) {}
 
+function flattenPrototype(obj) {
+  var copy = {};
+  for (var key in obj) {
+    copy[key] = obj[key];
+  }
+  return copy;
+}
+
 function serializeDependencies(deps) {
   return deps
   .map(function(dep) {
@@ -111,7 +119,7 @@ function serializeDependencies(deps) {
       request: dep.request,
       recursive: dep.recursive,
       regExp: dep.regExp ? dep.regExp.source : null,
-      loc: dep.loc,
+      loc: flattenPrototype(dep.loc),
     };
   })
   .filter(function(req) {

--- a/tests/fixtures/plugin-hmr-accept-dep/fib/index.js
+++ b/tests/fixtures/plugin-hmr-accept-dep/fib/index.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 2 : 0);
+};

--- a/tests/fixtures/plugin-hmr-accept-dep/index.js
+++ b/tests/fixtures/plugin-hmr-accept-dep/index.js
@@ -1,0 +1,9 @@
+var fib = require('./fib');
+
+console.log(fib(3));
+
+if (module.hot) {
+  module.hot.accept('./fib', function() {
+    console.log(require('./fib')(3));
+  });
+}

--- a/tests/fixtures/plugin-hmr-accept-dep/webpack.config.js
+++ b/tests/fixtures/plugin-hmr-accept-dep/webpack.config.js
@@ -1,0 +1,21 @@
+var HotModuleReplacementPlugin = require('webpack').HotModuleReplacementPlugin;
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HotModuleReplacementPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: __dirname + '/tmp/cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/plugin-hmr-accept/fib/index.js
+++ b/tests/fixtures/plugin-hmr-accept/fib/index.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 2 : 0);
+};

--- a/tests/fixtures/plugin-hmr-accept/index.js
+++ b/tests/fixtures/plugin-hmr-accept/index.js
@@ -1,0 +1,7 @@
+var fib = require('./fib');
+
+console.log(fib(3));
+
+if (module.hot) {
+  module.hot.accept(function() {});
+}

--- a/tests/fixtures/plugin-hmr-accept/webpack.config.js
+++ b/tests/fixtures/plugin-hmr-accept/webpack.config.js
@@ -1,0 +1,21 @@
+var HotModuleReplacementPlugin = require('webpack').HotModuleReplacementPlugin;
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HotModuleReplacementPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: __dirname + '/tmp/cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/plugin-hmr-process-env/fib/index.js
+++ b/tests/fixtures/plugin-hmr-process-env/fib/index.js
@@ -1,0 +1,8 @@
+module.exports = function(n) {
+  if (process.env.NODE_ENV !== "production") {
+    return n + (n > 0 ? n - 2 : 0);
+  }
+  else {
+    return n + (n > 0 ? n - 1 : 0);
+  }
+};

--- a/tests/fixtures/plugin-hmr-process-env/index.js
+++ b/tests/fixtures/plugin-hmr-process-env/index.js
@@ -1,0 +1,9 @@
+var fib = require('./fib');
+
+console.log(fib(3));
+
+if (module.hot) {
+  module.hot.accept('./fib', function() {
+    console.log(require('./fib')(3));
+  });
+}

--- a/tests/fixtures/plugin-hmr-process-env/webpack.config.js
+++ b/tests/fixtures/plugin-hmr-process-env/webpack.config.js
@@ -1,0 +1,21 @@
+var HotModuleReplacementPlugin = require('webpack').HotModuleReplacementPlugin;
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HotModuleReplacementPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: __dirname + '/tmp/cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -92,11 +92,11 @@ exports.compile = function(fixturePath, options) {
   ;
 };
 
-exports.compileTwiceEqual = function(fixturePath) {
-  var run1 = exports.compile(fixturePath);
+exports.compileTwiceEqual = function(fixturePath, compileOptions) {
+  var run1 = exports.compile(fixturePath, compileOptions);
   return run1
   .then(function() {
-    var run2 = exports.compile(fixturePath);
+    var run2 = exports.compile(fixturePath, compileOptions);
     return Promise.all([run1, run2]);
   })
   .then(function(runs) {
@@ -104,14 +104,14 @@ exports.compileTwiceEqual = function(fixturePath) {
   });
 };
 
-exports.itCompilesTwice = function(fixturePath) {
+exports.itCompilesTwice = function(fixturePath, compileOptions) {
   before(function() {
     return exports.clean(fixturePath);
   });
 
   it('builds identical ' + fixturePath + ' fixture', function() {
     this.timeout(10000);
-    return exports.compileTwiceEqual(fixturePath);
+    return exports.compileTwiceEqual(fixturePath, compileOptions);
   });
 };
 


### PR DESCRIPTION
Fix #39

`loc` is used for debugging info in webpack. Pointing to the line and
column in a file where a webpack dependency appears.
ModuleHotAcceptDependency creates a prototyped object to create this
info. Since JSON.stringify doesn't climb the prototype hierarchy for
info it serializes we need to do that ahead of time so `loc` is
complete.