### PR TITLE
Build a compiler prefix for modules based on subcache name

### DIFF
--- a/tests/fixtures/plugin-html-lodash/fact.js
+++ b/tests/fixtures/plugin-html-lodash/fact.js
@@ -1,0 +1,5 @@
+require('lodash');
+
+module.exports = function(n) {
+  return n * (n > 0 ? n - 2 : 0);
+};

--- a/tests/fixtures/plugin-html-lodash/fib.js
+++ b/tests/fixtures/plugin-html-lodash/fib.js
@@ -1,0 +1,5 @@
+require('./fact');
+
+module.exports = function(n) {
+  return n + (n > 0 ? n - 2 : 0);
+};

--- a/tests/fixtures/plugin-html-lodash/index.html
+++ b/tests/fixtures/plugin-html-lodash/index.html
@@ -1,0 +1,1 @@
+<html><head></head><body><div id="root"></div></body></html>

--- a/tests/fixtures/plugin-html-lodash/index.js
+++ b/tests/fixtures/plugin-html-lodash/index.js
@@ -1,0 +1,1 @@
+require('./fib');

--- a/tests/fixtures/plugin-html-lodash/webpack.config.js
+++ b/tests/fixtures/plugin-html-lodash/webpack.config.js
@@ -1,0 +1,26 @@
+var HtmlPlugin = require('html-webpack-plugin');
+
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HtmlPlugin({
+      template: 'index.html',
+      filename: 'index.html',
+      cache: false,
+    }),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -9,6 +9,7 @@ describe('plugin webpack use', function() {
 
   itCompilesTwice('plugin-dll');
   itCompilesTwice('plugin-dll-reference');
+  itCompilesTwice('plugin-html-lodash');
   itCompilesTwice('plugin-extract-text');
   itCompilesTwice('plugin-uglify-1dep');
   itCompilesTwice('plugin-extract-text-uglify');


### PR DESCRIPTION
Fix #31

Most child compilers need to use a subcache so their modules are built
considering their needs. We can reverse engineer a prefix following the
hierarchy of subcaches and the keys pointing to them.

An example of where this is needed is the html plugin and lodash.
Lodash relies on variable modules from webpack. One of those variables
needs a module to perform some utility. Since webpack assigns modules
ids, lodash in the html plugin and lodash used in a normal script built
by webpack will likely need separate modules to account for distinct
module ids of the utility module.