### PR TITLE
Return error in resolver immediately

### DIFF
--- a/index.js
+++ b/index.js
@@ -592,14 +592,15 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     params.normalModuleFactory.plugin('resolver', function(fn) {
       return function(request, cb) {
         fn.call(null, request, function(err, result) {
+          if (err) {return cb(err);}
+
           var identifierPrefix = cachePrefix(compilation);
           if (identifierPrefix === null) {
             return cb(err, result);
           }
           var identifier = identifierPrefix + result.request;
 
-          if (err) {return cb(err);}
-          else if (moduleCache[identifier]) {
+          if (moduleCache[identifier]) {
             var cacheItem = moduleCache[identifier];
             if (typeof cacheItem === 'string') {
               cacheItem = JSON.parse(cacheItem);

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -17,6 +17,7 @@ describe('basic webpack use - compiles identically', function() {
   itCompilesTwice('base-devtool-source-map');
   itCompilesTwice('base-devtool-cheap-source-map');
   itCompilesTwice('base-target-node-1dep');
+  itCompilesTwice('base-error-resolve');
 
 });
 

--- a/tests/fixtures/base-error-resolve/index.js
+++ b/tests/fixtures/base-error-resolve/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/base-error-resolve/webpack.config.js
+++ b/tests/fixtures/base-error-resolve/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Fix #46

Was trying to build the moduleCache identifier when errors could be
returned from upstream. In the case of an error (and no result)