### PR TITLE
Consider AMDDefineDependency a ConstDependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ catch (_) {
   };
 }
 
+var AMDDefineDependency = require('webpack/lib/dependencies/AMDDefineDependency');
 var AsyncDependenciesBlock = require('webpack/lib/AsyncDependenciesBlock');
 var ConstDependency = require('webpack/lib/dependencies/ConstDependency');
 var ContextDependency = require('webpack/lib/dependencies/ContextDependency');
@@ -181,7 +182,10 @@ function serializeDependencies(deps) {
     return {
       contextDependency: dep instanceof ContextDependency,
       contextCritical: dep.critical,
-      constDependency: dep instanceof ConstDependency,
+      constDependency: (
+        dep instanceof ConstDependency ||
+        dep instanceof AMDDefineDependency
+      ),
       request: dep.request,
       recursive: dep.recursive,
       regExp: dep.regExp ? dep.regExp.source : null,

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -18,6 +18,9 @@ describe('basic webpack use - compiles identically', function() {
   itCompilesTwice('base-devtool-cheap-source-map');
   itCompilesTwice('base-target-node-1dep');
   itCompilesTwice('base-error-resolve');
+  itCompilesTwice('base-amd-1dep');
+  itCompilesTwice('base-amd-context');
+  itCompilesTwice('base-amd-code-split');
 
 });
 

--- a/tests/fixtures/base-amd-1dep/fib.js
+++ b/tests/fixtures/base-amd-1dep/fib.js
@@ -1,0 +1,5 @@
+define(function() {
+  return function(n) {
+    return n + (n > 0 ? n - 1 : 0);
+  };
+});

--- a/tests/fixtures/base-amd-1dep/index.js
+++ b/tests/fixtures/base-amd-1dep/index.js
@@ -1,0 +1,3 @@
+define(['./fib'], function(fib) {
+  console.log(fib(3));
+});

--- a/tests/fixtures/base-amd-1dep/webpack.config.js
+++ b/tests/fixtures/base-amd-1dep/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/base-amd-code-split/fib.js
+++ b/tests/fixtures/base-amd-code-split/fib.js
@@ -1,0 +1,5 @@
+define(function() {
+  return function(n) {
+    return n + (n > 0 ? n - 1 : 0);
+  };
+});

--- a/tests/fixtures/base-amd-code-split/index.js
+++ b/tests/fixtures/base-amd-code-split/index.js
@@ -1,0 +1,3 @@
+require(['./fib'], function(fib) {
+  console.log(fib(3));
+});

--- a/tests/fixtures/base-amd-code-split/webpack.config.js
+++ b/tests/fixtures/base-amd-code-split/webpack.config.js
@@ -1,0 +1,16 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+    }),
+  ],
+};

--- a/tests/fixtures/base-amd-context/a/1.js
+++ b/tests/fixtures/base-amd-context/a/1.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/tests/fixtures/base-amd-context/a/2.js
+++ b/tests/fixtures/base-amd-context/a/2.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/tests/fixtures/base-amd-context/a/3.js
+++ b/tests/fixtures/base-amd-context/a/3.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/tests/fixtures/base-amd-context/a/4.js
+++ b/tests/fixtures/base-amd-context/a/4.js
@@ -1,0 +1,1 @@
+module.exports = 4;

--- a/tests/fixtures/base-amd-context/a/5.js
+++ b/tests/fixtures/base-amd-context/a/5.js
@@ -1,0 +1,1 @@
+module.exports = 5;

--- a/tests/fixtures/base-amd-context/a/index.js
+++ b/tests/fixtures/base-amd-context/a/index.js
@@ -1,0 +1,9 @@
+var a = '1';
+var b = '2';
+var c = '3';
+var d = '4';
+var e = '5';
+
+define(['./' + a, './' + b, './' + c, './' + d, './' + e], function(a, b, c, d, e) {
+  return (a + b + c + d + e);
+});

--- a/tests/fixtures/base-amd-context/b/10.js
+++ b/tests/fixtures/base-amd-context/b/10.js
@@ -1,0 +1,1 @@
+module.exports = 10;

--- a/tests/fixtures/base-amd-context/b/6.js
+++ b/tests/fixtures/base-amd-context/b/6.js
@@ -1,0 +1,1 @@
+module.exports = 6;

--- a/tests/fixtures/base-amd-context/b/7.js
+++ b/tests/fixtures/base-amd-context/b/7.js
@@ -1,0 +1,1 @@
+module.exports = 7;

--- a/tests/fixtures/base-amd-context/b/8.js
+++ b/tests/fixtures/base-amd-context/b/8.js
@@ -1,0 +1,1 @@
+module.exports = 8;

--- a/tests/fixtures/base-amd-context/b/9.js
+++ b/tests/fixtures/base-amd-context/b/9.js
@@ -1,0 +1,1 @@
+module.exports = 9;

--- a/tests/fixtures/base-amd-context/b/index.js
+++ b/tests/fixtures/base-amd-context/b/index.js
@@ -1,0 +1,6 @@
+module.exports =
+  require('./6') +
+  require('./7') +
+  require('./8') +
+  require('./9') +
+  require('./10');

--- a/tests/fixtures/base-amd-context/index.js
+++ b/tests/fixtures/base-amd-context/index.js
@@ -1,0 +1,1 @@
+console.log(require('./a') + require('./b'));

--- a/tests/fixtures/base-amd-context/webpack.config.js
+++ b/tests/fixtures/base-amd-context/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Fix #49

AMDDefineDependency works like ConstDependencies but doesn't subclass
it. Treating it like ConstDependency we save a dependency object when
serializing AMD modules so they can be deserialized to work when they
just export a value.