### PR TITLE
Fix context dependency rebuild check

### DIFF
--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -45,7 +45,11 @@ HardModule.prototype = Object.create(RawModule.prototype);
 HardModule.prototype.constructor = HardModule;
 
 function needRebuild(buildTimestamp, fileDependencies, contextDependencies, fileTimestamps, contextTimestamps, fileMd5s, cachedMd5s) {
-  var timestamp = 0;
+  // NormalModule#needRebuild in webpack computes file and context together.
+  // Since we also handle hashed versions of the files but not the contexts we
+  // need to consider the timestamps separately.
+  var fileTimestamp = 0;
+  var contextTimestamp = 0;
   var needsMd5Rebuild = !(fileMd5s && cachedMd5s);
 
   fileDependencies.forEach(function(file) {
@@ -53,15 +57,18 @@ function needRebuild(buildTimestamp, fileDependencies, contextDependencies, file
       needsMd5Rebuild = cachedMd5s[file] !== fileMd5s[file];
     }
     var ts = fileTimestamps[file];
-    if(!ts) timestamp = Infinity;
-    if(ts > timestamp) timestamp = ts;
+    if(!ts) fileTimestamp = Infinity;
+    if(ts > fileTimestamp) fileTimestamp = ts;
   });
   contextDependencies.forEach(function(context) {
     var ts = contextTimestamps[context];
-    if(!ts) timestamp = Infinity;
-    if(ts > timestamp) timestamp = ts;
+    if(!ts) contextTimestamp = Infinity;
+    if(ts > contextTimestamp) contextTimestamp = ts;
   });
-  return timestamp >= buildTimestamp && needsMd5Rebuild;
+  return (
+    fileTimestamp >= buildTimestamp && needsMd5Rebuild ||
+    contextTimestamp >= buildTimestamp
+  );
 }
 
 HardModule.needRebuild = needRebuild;

--- a/tests/fixtures/loader-custom-context-dep/dir/file
+++ b/tests/fixtures/loader-custom-context-dep/dir/file
@@ -1,0 +1,1 @@
+// dir/file/b

--- a/tests/fixtures/loader-custom-context-dep/fib.js
+++ b/tests/fixtures/loader-custom-context-dep/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/loader-custom-context-dep/index.js
+++ b/tests/fixtures/loader-custom-context-dep/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/loader-custom-context-dep/loader.js
+++ b/tests/fixtures/loader-custom-context-dep/loader.js
@@ -1,0 +1,11 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  this.addContextDependency(path.join(__dirname, 'dir'));
+  return [
+    fs.readFileSync(path.join(__dirname, 'dir', 'file'), 'utf8'),
+    source
+  ].join('\n');
+};

--- a/tests/fixtures/loader-custom-context-dep/webpack.config.js
+++ b/tests/fixtures/loader-custom-context-dep/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './loader.js!./index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -39,6 +39,19 @@ describe('loader webpack warnings & errors', function() {
 
 describe('loader webpack use - builds changes', function() {
 
+  itCompilesChange('loader-custom-context-dep', {
+    'dir/file': [
+      '// dir/file/a',
+    ].join('\n'),
+  }, {
+    'dir/file': [
+      '// dir/file/b',
+    ].join('\n'),
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/dir\/file\/a/);
+    expect(output.run2['main.js'].toString()).to.match(/dir\/file\/b/);
+  });
+
   itCompilesChange('loader-custom-prepend-helper', {
     'loader-helper.js': [
       'function helper(a) {',


### PR DESCRIPTION
Fix #59

Need to consider context timestamps separately until we build context hashes.

- Add a test to make sure rebuilds happen on context dependencies