### PR TITLE
Bust modules that use keys of a busted es2015 module

### DIFF
--- a/tests/base-webpack-2.js
+++ b/tests/base-webpack-2.js
@@ -68,6 +68,23 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     expect(output.run2['main.js'].toString()).to.contain('exports["a"]');
   });
 
+  itCompilesChange('base-change-es2015-export-order-module', {
+    'other.js': [
+      'import {fib, key} from \'./obj\';',
+      'console.log(fib);',
+      'console.log(key);',
+    ].join('\n'),
+  }, {
+    'other.js': [
+      'import {fib, key} from \'./obj\';',
+      'console.log(key);',
+      'console.log(fib);',
+    ].join('\n'),
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.contain('console.log(__WEBPACK_IMPORTED_MODULE_0__obj__["a" /* fib */], __WEBPACK_IMPORTED_MODULE_0__obj__["b" /* key */]);');
+    expect(output.run2['main.js'].toString()).to.contain('console.log(__WEBPACK_IMPORTED_MODULE_0__obj__["b" /* fib */], __WEBPACK_IMPORTED_MODULE_0__obj__["a" /* key */]);');
+  });
+
   itCompilesChange('base-change-es2015-all-module', {
     'index.js': [
       'import {key} from \'./obj\';',

--- a/tests/fixtures/base-change-es2015-export-order-module/index.js
+++ b/tests/fixtures/base-change-es2015-export-order-module/index.js
@@ -1,0 +1,2 @@
+import {key, fib} from './obj';
+console.log(fib, key);

--- a/tests/fixtures/base-change-es2015-export-order-module/obj.js
+++ b/tests/fixtures/base-change-es2015-export-order-module/obj.js
@@ -1,0 +1,5 @@
+import './other';
+export function fib(n) {
+  return n + (n > 0 ? n - 1 : 0);
+}
+export let key = 'obj';

--- a/tests/fixtures/base-change-es2015-export-order-module/other.js
+++ b/tests/fixtures/base-change-es2015-export-order-module/other.js
@@ -1,0 +1,3 @@
+import {fib, key} from './obj';
+console.log(key);
+console.log(fib);

--- a/tests/fixtures/base-change-es2015-export-order-module/webpack.config.js
+++ b/tests/fixtures/base-change-es2015-export-order-module/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Fix #60

ES2015 modules have the keys used determined by their dependents. The
order if changed needs to be updated in all dependents instead of just
the modules that caused the change.