### PR TITLE
Version stamp the cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,6 +137,9 @@ function cachePrefix(compilation) {
 }
 
 function flattenPrototype(obj) {
+  if (typeof obj === 'string') {
+    return obj;
+  }
   var copy = {};
   for (var key in obj) {
     copy[key] = obj[key];


### PR DESCRIPTION
Fix #57

- Stamp the cache with the version to help make sure old caches aren't used
- Return string dep.loc values as is