### PR TITLE
Validate resolveCache with resolve.resource

### DIFF
--- a/index.js
+++ b/index.js
@@ -592,8 +592,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           var resolveItem = resolveCache[resolveId];
           validDepends = validDepends &&
             resolveItem &&
-            resolveItem.userRequest &&
-            fileTs[resolveItem.userRequest] !== 0;
+            resolveItem.resource &&
+            Boolean(fileTs[resolveItem.resource.split('?')[0]]);
         });
         if (!validDepends) {
           cacheItem.invalid = true;
@@ -713,17 +713,12 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         };
 
         if (resolveCache[cacheId]) {
-          var userRequest = resolveCache[cacheId].userRequest;
-          if (fileTimestamps[userRequest]) {
+          var resource = resolveCache[cacheId].resource.split('?')[0];
+          if (fileTimestamps[resource]) {
             return fromCache();
           }
-          return fs.stat(userRequest, function(err) {
-            if (!err) {
-              return fromCache();
-            }
-
-            next();
-          });
+          return stat(resource)
+          .then(fromCache, next);
         }
 
         next();

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -44,6 +44,8 @@ function HardModule(cacheItem) {
 HardModule.prototype = Object.create(RawModule.prototype);
 HardModule.prototype.constructor = HardModule;
 
+HardModule.prototype.isHard = function() {return true;};
+
 function needRebuild(buildTimestamp, fileDependencies, contextDependencies, fileTimestamps, contextTimestamps, fileMd5s, cachedMd5s) {
   // NormalModule#needRebuild in webpack computes file and context together.
   // Since we also handle hashed versions of the files but not the contexts we

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -2,6 +2,7 @@ var expect = require('chai').expect;
 
 var itCompilesTwice = require('./util').itCompilesTwice;
 var itCompilesChange = require('./util').itCompilesChange;
+var itCompilesHardModules = require('./util').itCompilesHardModules;
 
 describe('basic webpack use - compiles identically', function() {
 

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -25,6 +25,14 @@ describe('basic webpack use - compiles identically', function() {
 
 });
 
+describe('basic webpack use - compiles hard modules', function() {
+
+  itCompilesHardModules('base-1dep', ['./fib.js', './index.js']);
+  itCompilesHardModules('base-code-split', ['./fib.js', './index.js']);
+  itCompilesHardModules('base-query-request', ['./fib.js?argument']);
+
+});
+
 describe('basic webpack use - builds changes', function() {
 
   itCompilesChange('base-change-1dep', {

--- a/tests/fixtures/base-query-request/fib.js
+++ b/tests/fixtures/base-query-request/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-query-request/index.js
+++ b/tests/fixtures/base-query-request/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib?argument');
+
+console.log(fib(3));

--- a/tests/fixtures/base-query-request/webpack.config.js
+++ b/tests/fixtures/base-query-request/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/loader-custom-user-loader/fib.js
+++ b/tests/fixtures/loader-custom-user-loader/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/loader-custom-user-loader/index.js
+++ b/tests/fixtures/loader-custom-user-loader/index.js
@@ -1,0 +1,1 @@
+require('./loader.js!./fib.js');

--- a/tests/fixtures/loader-custom-user-loader/loader.js
+++ b/tests/fixtures/loader-custom-user-loader/loader.js
@@ -1,0 +1,4 @@
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  return source;
+};

--- a/tests/fixtures/loader-custom-user-loader/webpack.config.js
+++ b/tests/fixtures/loader-custom-user-loader/webpack.config.js
@@ -1,0 +1,27 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './loader!./index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  module: {
+    loaders: [
+      {
+        test: /\.png$/,
+        loader: 'file-loader',
+      },
+    ],
+  },
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -3,6 +3,7 @@ var expect = require('chai').expect;
 var util = require('./util');
 var itCompilesTwice = util.itCompilesTwice;
 var itCompilesChange = util.itCompilesChange;
+var itCompilesHardModules = util.itCompilesHardModules;
 var clean = util.clean;
 var compile = util.compile;
 
@@ -10,6 +11,10 @@ describe('loader webpack use', function() {
 
   itCompilesTwice('loader-css');
   itCompilesTwice('loader-file');
+
+  itCompilesHardModules('loader-css', ['./index.css']);
+  itCompilesHardModules('loader-file', ['./image.png']);
+  itCompilesHardModules('loader-custom-user-loader', ['./loader.js!./index.js']);
 
 });
 

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -4,6 +4,7 @@ var clean = require('./util').clean;
 var compile = require('./util').compile;
 var itCompilesTwice = require('./util').itCompilesTwice;
 var itCompilesChange = require('./util').itCompilesChange;
+var itCompilesHardModules = require('./util').itCompilesHardModules;
 
 describe('plugin webpack use', function() {
 
@@ -22,6 +23,8 @@ describe('plugin webpack use', function() {
   itCompilesTwice('plugin-hmr-accept', {exportStats: true});
   itCompilesTwice('plugin-hmr-accept-dep', {exportStats: true});
   itCompilesTwice('plugin-hmr-process-env', {exportStats: true});
+
+  itCompilesHardModules('plugin-html-lodash', [/lodash\/lodash\.js$/, /\!\.\/index\.html$/]);
 
 });
 


### PR DESCRIPTION
Resolve with resource which has no loaders. userRequest can have
loaders specified in the dependency. query parameters that can be on
the resource also need to be popped off for the resolve check.

This was leading to some modules being invalidated due to a false
positive.