### PR TITLE
Build the env hash with an internal implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,7 +547,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       .then(function() {
         var setter = setKey(fileMd5s, file, '');
         if (
-          md5Cache[file] && fileTs[file] > md5Cache[file].mtime ||
+          md5Cache[file] && fileTs[file] >= md5Cache[file].mtime ||
           !md5Cache[file] ||
           !fileTs[file]
         ) {

--- a/index.js
+++ b/index.js
@@ -756,7 +756,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
             }
 
             if (!HardModule.needRebuild(
-              cacheItem.buildTimestamp,
+              cacheItem,
               cacheItem.fileDependencies,
               cacheItem.contextDependencies,
               // [],

--- a/index.js
+++ b/index.js
@@ -8,16 +8,16 @@ var mkdirp = require('mkdirp');
 
 var Promise = require('bluebird');
 
-var envHash;
-try {
-  envHash = require('env-hash');
-  envHash = envHash.default || envHash;
-}
-catch (_) {
-  envHash = function() {
-    return Promise.resolve('');
-  };
-}
+var envHash = require('./lib/env-hash');
+// try {
+//   envHash = require('env-hash');
+//   envHash = envHash.default || envHash;
+// }
+// catch (_) {
+//   envHash = function() {
+//     return Promise.resolve('');
+//   };
+// }
 
 var AMDDefineDependency = require('webpack/lib/dependencies/AMDDefineDependency');
 var AsyncDependenciesBlock = require('webpack/lib/AsyncDependenciesBlock');

--- a/lib/env-hash.js
+++ b/lib/env-hash.js
@@ -1,0 +1,96 @@
+// - scan dirs
+//   - stat items
+//   - hash files
+//   - stat dir items under
+//     - hash files
+// - hash files
+
+var crypto = require('crypto');
+var fs = require('fs');
+var path = require('path');
+
+var Promise = require('bluebird');
+
+var readFile = Promise.promisify(fs.readFile);
+var readdir = Promise.promisify(fs.readdir);
+var stat = Promise.promisify(fs.stat);
+
+function hashFile(file) {
+  return readFile(file)
+  .then(function(src) {
+    return [file, crypto.createHash('md5').update(src).digest('hex')];
+  })
+  .catch(function() {});
+}
+
+function hashObject(obj) {
+  var hash = crypto.createHash('md5');
+  obj.forEach(function(item) {
+    hash.update(item[0]);
+    hash.update(item[1]);
+  });
+  return hash.digest('hex');
+}
+
+function hashFiles(root, files) {
+  return Promise.all(files.map(function(file) {
+    return hashFile(path.join(root, file));
+  }))
+  .then(function(hashes) {return hashes.filter(Boolean);});
+}
+
+function flatten(items) {
+  return (items || []).reduce(function(carry, item) {
+    return item ? carry.concat(item) : carry;
+  }, []);
+}
+
+module.exports = function(options) {
+  options = options || {};
+  var root = options.root || process.cwd();
+  var files = options.files || ['package.json'];
+  var directories = options.directories || ['node_modules'];
+
+  return Promise.all([
+    hashFiles(root, files),
+    Promise.all(directories.map(function(dir) {
+      return readdir(path.join(root, dir))
+      .then(function(items) {
+        return Promise.all(items.map(function(item) {
+          return stat(path.join(root, dir, item))
+          .then(function(stat) {
+            if (stat.isDirectory()) {
+              return hashFiles(path.join(root, dir, item), files);
+            }
+            if (stat.isFile()) {
+              return hashFile(path.join(root, dir, item))
+              .then(function(hash) {return hash ? [hash] : hash;});
+            }
+          })
+          .catch(function() {console.error(arguments)});
+        }))
+        .then(function(hashes) {return hashes.filter(Boolean);});
+      })
+      .catch(function() {})
+      .then(flatten);
+    }))
+    .then(flatten),
+  ])
+  .then(flatten)
+  .then(function(items) {
+    items.forEach(function(item) {
+      item[0] = path.relative(root, item[0]);
+    });
+    // console.log(items);
+    items.sort(function(a, b) {
+      if (a[0] < b[0]) {
+        return -1;
+      }
+      else if (a[0] > b[0]) {
+        return 1;
+      }
+      return 0;
+    });
+    return hashObject(items);
+  });
+};

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -46,17 +46,18 @@ HardModule.prototype.constructor = HardModule;
 
 HardModule.prototype.isHard = function() {return true;};
 
-function needRebuild(buildTimestamp, fileDependencies, contextDependencies, fileTimestamps, contextTimestamps, fileMd5s, cachedMd5s) {
+function needRebuild(cacheItem, fileDependencies, contextDependencies, fileTimestamps, contextTimestamps, fileMd5s, cachedMd5s) {
   // NormalModule#needRebuild in webpack computes file and context together.
   // Since we also handle hashed versions of the files but not the contexts we
   // need to consider the timestamps separately.
   var fileTimestamp = 0;
   var contextTimestamp = 0;
+  var buildTimestamp = cacheItem.buildTimestamp;
   var needsMd5Rebuild = !(fileMd5s && cachedMd5s);
 
   fileDependencies.forEach(function(file) {
     if (!needsMd5Rebuild) {
-      needsMd5Rebuild = cachedMd5s[file] !== fileMd5s[file];
+      needsMd5Rebuild = cachedMd5s[file] !== fileMd5s[file] || !cachedMd5s[file];
     }
     var ts = fileTimestamps[file];
     if(!ts) fileTimestamp = Infinity;
@@ -67,15 +68,20 @@ function needRebuild(buildTimestamp, fileDependencies, contextDependencies, file
     if(!ts) contextTimestamp = Infinity;
     if(ts > contextTimestamp) contextTimestamp = ts;
   });
+  if (needsMd5Rebuild && fileMd5s && cachedMd5s) {
+    cacheItem.invalid = true;
+  }
   return (
+    cacheItem.invalid ||
     fileTimestamp >= buildTimestamp && needsMd5Rebuild ||
-    contextTimestamp >= buildTimestamp
+    contextTimestamp >= buildTimestamp ||
+    needsMd5Rebuild && fileMd5s && cachedMd5s
   );
 }
 
 HardModule.needRebuild = needRebuild;
 HardModule.prototype.needRebuild = function(fileTimestamps, contextTimestamps) {
-  return this.cacheItem.invalid || needRebuild(this.buildTimestamp, this.fileDependencies, this.contextDependencies, fileTimestamps, contextTimestamps);
+  return this.cacheItem.invalid || needRebuild(this.cacheItem, this.fileDependencies, this.contextDependencies, fileTimestamps, contextTimestamps);
 };
 
 HardModule.prototype.source = function() {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "bluebird": "^3.0.0",
-    "env-hash": "^1.1.0",
     "level": "^1.4.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -192,7 +192,7 @@ exports.itCompiles = function(name, fixturePath, fnA, fnB, expectHandle) {
     })
     // Delay enough time so that file timestamps are different.
     .then(function() {
-      return new Promise(function(resolve) {setTimeout(resolve, 1000);});
+      // return new Promise(function(resolve) {setTimeout(resolve, 1000);});
     })
     .then(function() {
       return fnB();
@@ -230,7 +230,7 @@ exports.itCompilesWithCache = function(name, fixturePath, fnA, fnB, expectHandle
       return exports.compile(fixturePath);
     })
     .then(function() {
-      return new Promise(function(resolve) {setTimeout(resolve, 1000);});
+      // return new Promise(function(resolve) {setTimeout(resolve, 1000);});
     })
     .then(function() {
       var serializer = new LevelDbSerializer({
@@ -245,7 +245,7 @@ exports.itCompilesWithCache = function(name, fixturePath, fnA, fnB, expectHandle
       return exports.compile(fixturePath);
     })
     .then(function() {
-      return new Promise(function(resolve) {setTimeout(resolve, 1000);});
+      // return new Promise(function(resolve) {setTimeout(resolve, 1000);});
     })
     .then(function() {
       var serializer = new LevelDbSerializer({


### PR DESCRIPTION
npm's env-hash focuses on building its hash with mtime. This builds the
hash from file hashes. This helps support using HardSource in CI and
server environments with a shared pre-existing cache.