### PR TITLE
Test depending on missing file dependencies

### DIFF
--- a/tests/fixtures/loader-custom-missing-dep-added/index.js
+++ b/tests/fixtures/loader-custom-missing-dep-added/index.js
@@ -1,0 +1,1 @@
+console.log(fib(3));

--- a/tests/fixtures/loader-custom-missing-dep-added/loader.js
+++ b/tests/fixtures/loader-custom-missing-dep-added/loader.js
@@ -1,0 +1,18 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  var file = path.join(__dirname, 'fib.js');
+  try {
+    fs.statSync(file);
+    return [
+      'var fib = require("./fib.js");',
+      source,
+    ].join('\n');
+  }
+  catch (_) {
+    this.addDependency(file);
+  }
+  return source;
+};

--- a/tests/fixtures/loader-custom-missing-dep-added/webpack.config.js
+++ b/tests/fixtures/loader-custom-missing-dep-added/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './loader.js!./index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/loader-custom-missing-dep/loader.js
+++ b/tests/fixtures/loader-custom-missing-dep/loader.js
@@ -1,0 +1,8 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  this.addDependency(path.join(__dirname, 'fib.js'));
+  return source;
+};

--- a/tests/fixtures/loader-custom-missing-dep/webpack.config.js
+++ b/tests/fixtures/loader-custom-missing-dep/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './loader.js!./index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -11,6 +11,7 @@ describe('loader webpack use', function() {
 
   itCompilesTwice('loader-css');
   itCompilesTwice('loader-file');
+  itCompilesTwice('loader-custom-missing-dep');
 
   itCompilesHardModules('loader-css', ['./index.css']);
   itCompilesHardModules('loader-file', ['./image.png']);
@@ -87,6 +88,32 @@ describe('loader webpack use - builds changes', function() {
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.match(/console\.log\(a\)/);
     expect(output.run2['main.js'].toString()).to.match(/console\.log\(b\)/);
+  });
+
+  itCompilesChange('loader-custom-missing-dep-added', {
+    'fib.js': null,
+  }, {
+    'fib.js': [
+      'module.exports = function(n) {',
+      '  return n + (n > 0 ? n - 1 : 0);',
+      '};',
+    ].join('\n'),
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.not.match(/n - 1/);
+    expect(output.run2['main.js'].toString()).to.match(/n - 1/);
+  });
+
+  itCompilesChange('loader-custom-missing-dep-added', {
+    'fib.js': [
+      'module.exports = function(n) {',
+      '  return n + (n > 0 ? n - 1 : 0);',
+      '};',
+    ].join('\n'),
+  }, {
+    'fib.js': null,
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/n - 1/);
+    expect(output.run2['main.js'].toString()).to.not.match(/n - 1/);
   });
 
 });


### PR DESCRIPTION
Loaders can depend on files that do not exist and then should be
rebuilt when those files do exist.