### PR TITLE
Support DelegatedModules

### DIFF
--- a/index.js
+++ b/index.js
@@ -608,52 +608,6 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         }
       });
     })
-    .then(function() {
-      // Invalidate modules that depend on a userRequest that is no longer
-      // valid.
-      var walkDependencyBlock = function(block, callback) {
-        block.dependencies.forEach(callback);
-        block.variables.forEach(function(variable) {
-          variable.dependencies.forEach(callback);
-        });
-        block.blocks.forEach(function(block) {
-          walkDependencyBlock(block, callback);
-        });
-      };
-      // Remove the out of date cache modules.
-      Object.keys(moduleCache).forEach(function(key) {
-        var cacheItem = moduleCache[key];
-        if (!cacheItem) {return;}
-        if (typeof cacheItem === 'string') {
-          cacheItem = JSON.parse(cacheItem);
-          moduleCache[key] = cacheItem;
-        }
-        var validDepends = true;
-        walkDependencyBlock(cacheItem, function(cacheDependency) {
-          if (
-            !cacheDependency ||
-            cacheDependency.contextDependency ||
-            typeof cacheDependency.request === 'undefined'
-          ) {
-            return;
-          }
-
-          var resolveId = JSON.stringify(
-            [cacheItem.context, cacheDependency.request]
-          );
-          var resolveItem = resolveCache[resolveId];
-          validDepends = validDepends &&
-            resolveItem &&
-            resolveItem.resource &&
-            Boolean(fileTs[resolveItem.resource.split('?')[0]]);
-        });
-        if (!validDepends) {
-          // console.log('invalid', key);
-          // cacheItem.invalid = true;
-          // moduleCache[key] = null;
-        }
-      });
-    })
     .then(function() {cb();}, cb);
   });
 

--- a/index.js
+++ b/index.js
@@ -421,6 +421,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
               });
             }));
           })
+          .catch(() => [])
           .then(function(items) {
             return items.reduce(function(carry, item) {
               return carry.concat(item);

--- a/index.js
+++ b/index.js
@@ -94,27 +94,27 @@ function flattenPrototype(obj) {
   return copy;
 }
 
-function serializeDependencies(deps) {
+function serializeDependencies(deps, parent) {
   return deps
   .map(function(dep) {
+    var cacheDep;
     if (typeof HarmonyImportDependency !== 'undefined') {
       if (dep instanceof HarmonyImportDependency) {
-        return {
-          moduleIdentifier: dep.module && dep.module.identifier(),
+        cacheDep = {
           harmonyImport: true,
           request: dep.request,
         };
       }
-      if (dep instanceof HarmonyExportImportedSpecifierDependency) {
-        return {
+      else if (dep instanceof HarmonyExportImportedSpecifierDependency) {
+        cacheDep = {
           harmonyRequest: dep.importDependency.request,
           harmonyExportImportedSpecifier: true,
           harmonyId: dep.id,
           harmonyName: dep.name,
         };
       }
-      if (dep instanceof HarmonyImportSpecifierDependency) {
-        return {
+      else if (dep instanceof HarmonyImportSpecifierDependency) {
+        cacheDep = {
           harmonyRequest: dep.importDependency.request,
           harmonyImportSpecifier: true,
           harmonyId: dep.id,
@@ -123,50 +123,64 @@ function serializeDependencies(deps) {
         };
       }
     }
-    if (dep.originModule) {
-      return {
+    if (!cacheDep && dep.originModule) {
+      cacheDep = {
         harmonyExport: true,
         harmonyId: dep.id,
         harmonyName: dep.describeHarmonyExport().exportedName,
         harmonyPrecedence: dep.describeHarmonyExport().precedence,
       };
     }
-    return {
-      moduleIdentifier: dep.module && dep.module.identifier(),
-      contextDependency: dep instanceof ContextDependency,
-      contextCritical: dep.critical,
-      constDependency: (
-        dep instanceof ConstDependency ||
-        dep instanceof AMDDefineDependency
-      ),
-      request: dep.request,
-      recursive: dep.recursive,
-      regExp: dep.regExp ? dep.regExp.source : null,
-      async: dep.async,
-      loc: flattenPrototype(dep.loc),
-    };
+    if (!cacheDep) {
+      cacheDep = {
+        contextDependency: dep instanceof ContextDependency,
+        contextCritical: dep.critical,
+        constDependency: (
+          dep instanceof ConstDependency ||
+          dep instanceof AMDDefineDependency
+        ),
+        request: dep.request,
+        recursive: dep.recursive,
+        regExp: dep.regExp ? dep.regExp.source : null,
+        async: dep.async,
+        loc: flattenPrototype(dep.loc),
+      };
+    }
+
+    // The identifier this dependency should resolve to.
+    var _resolvedModuleIdentifier = dep.module && dep.module.identifier();
+    // An identifier to dereference a dependency under a module to some per
+    // dependency value
+    var _inContextDependencyIdentifier = parent && JSON.stringify([parent.context, cacheDep]);
+    // An identifier from the dependency to the cached resolution information
+    // for building a module.
+    var _resolveCacheId = parent && cacheDep.request && JSON.stringify([parent.context, cacheDep.request]);
+    cacheDep._resolvedModuleIdentifier = _resolvedModuleIdentifier;
+    cacheDep._inContextDependencyIdentifier = _inContextDependencyIdentifier;
+    cacheDep._resolveCacheId = _resolveCacheId;
+    return cacheDep;
   })
   .filter(function(req) {
     return req.request || req.constDependency || req.harmonyExport || req.harmonyImportSpecifier || req.harmonyExportImportedSpecifier;
   });
 }
-function serializeVariables(vars) {
+function serializeVariables(vars, parent) {
   return vars.map(function(variable) {
     return {
       name: variable.name,
       expression: variable.expression,
-      dependencies: serializeDependencies(variable.dependencies),
+      dependencies: serializeDependencies(variable.dependencies, parent),
     }
   });
 }
-function serializeBlocks(blocks) {
+function serializeBlocks(blocks, parent) {
   return blocks.map(function(block) {
     return {
       async: block instanceof AsyncDependenciesBlock,
       name: block.chunkName,
-      dependencies: serializeDependencies(block.dependencies),
-      variables: serializeVariables(block.variables),
-      blocks: serializeBlocks(block.blocks),
+      dependencies: serializeDependencies(block.dependencies, parent),
+      variables: serializeVariables(block.variables, parent),
+      blocks: serializeBlocks(block.blocks, parent),
     };
   });
 }
@@ -671,6 +685,189 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     });
   });
 
+  function getModuleCacheItem(compilation, result) {
+    // a map of dependency identifiers to factory.create checks
+    var checkedDependencies =
+      compilation.__hardSource_checkedDependencies =
+      compilation.__hardSource_checkedDependencies || {};
+    // a map of module identifiers to fully checked modules
+    var checkedModules =
+      compilation.__hardSource_checkedModules =
+      compilation.__hardSource_checkedModules || {};
+
+    if (checkedModules[result.request]) {
+      return checkedModules[result.request];
+    }
+
+    var identifierPrefix = cachePrefix(compilation);
+    if (identifierPrefix === null) {
+      return;
+    }
+    var identifier = identifierPrefix + result.request;
+
+    if (moduleCache[identifier] && !moduleCache[identifier].invalid) {
+      var cacheItem = moduleCache[identifier];
+
+      if (typeof cacheItem === 'string') {
+        cacheItem = JSON.parse(cacheItem);
+        moduleCache[identifier] = cacheItem;
+      }
+      if (Array.isArray(cacheItem.assets)) {
+        cacheItem.assets = (cacheItem.assets || [])
+        .reduce(function(carry, key) {
+          carry[key] = assetCache[requestHash(key)];
+          return carry;
+        }, {});
+      }
+
+      if (!HardModule.needRebuild(
+        cacheItem,
+        cacheItem.fileDependencies,
+        cacheItem.contextDependencies,
+        fileTimestamps,
+        contextTimestamps,
+        fileMd5s,
+        cachedMd5s
+      )) {
+        var promise = null;
+
+        var walkDependencyBlock = function(block, callback) {
+          var addPromise = function(item) {
+            var p = callback(item);
+            if (p && p.then) {
+              if (!promise) {promise = [];}
+              promise.push(p);
+            }
+          };
+          block.dependencies.forEach(addPromise)
+          block.variables.forEach(function(variable) {
+            variable.dependencies.forEach(addPromise);
+          })
+          block.blocks.forEach(function(block) {
+            walkDependencyBlock(block, callback);
+          })
+        };
+
+        var state = {state: {imports: {}}};
+
+        walkDependencyBlock(cacheItem, function(cacheDependency) {
+          if (
+            cacheDependency &&
+            !cacheDependency.contextDependency &&
+            typeof cacheDependency.request !== 'undefined'
+          ) {
+            var resolveId = cacheDependency._resolveCacheId;
+            var resolveItem = resolveCache[resolveId];
+            if (
+              resolveItem &&
+              // !resolveItem.invalid
+              resolveItem.request &&
+              resolveItem.resource &&
+              fileTimestamps[resolveItem.resource.split('?')[0]]
+            ) {
+              var depIdentifier = identifierPrefix + resolveItem.request;
+              var depCacheItem = moduleCache[depIdentifier];
+              if (
+                depCacheItem &&
+                depCacheItem.fileDependencies
+                .reduce(function(carry, file) {
+                  return carry && fileTimestamps[file];
+                }, true) &&
+                depCacheItem.contextDependencies
+                .reduce(function(carry, dir) {
+                  return carry && contextTimestamps[dir];
+                }, true)
+              ) {
+                return;
+              }
+              else if (depCacheItem) {
+                return;
+              }
+            }
+            // else if (resolveItem && resolveItem.invalid) {
+            //   cacheItem.invalid = true;
+            //   return;
+            // }
+          }
+
+          if (
+            cacheDependency._resolvedModuleIdentifier &&
+            cacheDependency._inContextDependencyIdentifier
+          ) {
+            var dependencyIdentifier = cacheDependency._inContextDependencyIdentifier;
+            if (!checkedDependencies[dependencyIdentifier]) {
+              var dependency = deserializeDependencies.dependencies.call(state, [cacheDependency], null)[0];
+              var factory = compilation.dependencyFactories.get(dependency.constructor);
+              var p = new Promise(function(resolve, reject) {
+                var callFactory = function(fn) {
+                  if (factory.create.length === 2) {
+                    factory.create({
+                      contextInfo: {
+                        issuer: cacheItem.resource.split('?')[0],
+                      },
+                      context: cacheItem.context,
+                      dependencies: [dependency],
+                    }, fn);
+                  }
+                  if (factory.create.length === 3) {
+                    factory.create(cacheItem.context, dependency, fn);
+                  }
+                };
+                callFactory(function(err, depModule) {
+                  if (
+                    !checkedDependencies[dependencyIdentifier] ||
+                    checkedDependencies[dependencyIdentifier].then
+                  ) {
+                    checkedDependencies[dependencyIdentifier] = cacheItem;
+                  }
+                  if (err) {
+                    cacheItem.invalid = true;
+                    return reject(err);
+                  }
+                  if (cacheDependency._resolvedModuleIdentifier === depModule.identifier()) {
+                    return resolve();
+                  }
+                  cacheItem.invalid = true;
+                  reject(new Error('dependency has a new identifier'));
+                });
+              });
+              if (!checkedDependencies[dependencyIdentifier]) {
+                checkedDependencies[dependencyIdentifier] = p;
+              }
+            }
+            return checkedDependencies[dependencyIdentifier];
+          }
+        });
+
+        if (promise && promise.length) {
+          return Promise.all(promise)
+          .then(function() {
+            if (!cacheItem || cacheItem.invalid) {
+              return Promise.reject();
+            }
+            checkedModules[result.request] = cacheItem;
+            return cacheItem;
+          })
+          .catch(function(e) {
+            cacheItem.invalid = true;
+            moduleCache[identifier] = null;
+            return Promise.reject();
+          });
+        }
+        else {
+          if (!cacheItem || cacheItem.invalid) {
+            if (cacheItem) {
+              cacheItem = null;
+            }
+            moduleCache[identifier] = null;
+          }
+          checkedModules[result.request] = cacheItem;
+          return cacheItem;
+        }
+      }
+    }
+  }
+
   compiler.plugin('compilation', function(compilation, params) {
     if (!active) {return;}
 
@@ -798,136 +995,24 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         fn.call(null, request, function(err, result) {
           if (err) {return cb(err);}
 
-          var identifierPrefix = cachePrefix(compilation);
-          if (identifierPrefix === null) {
-            return cb(err, result);
+          var p = getModuleCacheItem(compilation, result);
+          if (p && p.then) {
+            return p
+            .then(function(cacheItem) {
+              // console.log('valid', cacheItem.identifier);
+              var module = new HardModule(cacheItem);
+              cb(null, module);
+            })
+            .catch(function() {
+              // console.log('invalid', result.request);
+              cb(err, result);
+            });
           }
-          var identifier = identifierPrefix + result.request;
-
-          if (moduleCache[identifier]) {
-            var cacheItem = moduleCache[identifier];
-
-            if (typeof cacheItem === 'string') {
-              cacheItem = JSON.parse(cacheItem);
-              moduleCache[identifier] = cacheItem;
-            }
-            if (Array.isArray(cacheItem.assets)) {
-              cacheItem.assets = (cacheItem.assets || [])
-              .reduce(function(carry, key) {
-                carry[key] = assetCache[requestHash(key)];
-                return carry;
-              }, {});
-            }
-
-            if (!HardModule.needRebuild(
-              cacheItem,
-              cacheItem.fileDependencies,
-              cacheItem.contextDependencies,
-              // [],
-              fileTimestamps,
-              contextTimestamps,
-              fileMd5s,
-              cachedMd5s
-            )) {
-              var walkDependencyBlock = function(block, callback) {
-                return Promise.all(
-                  block.dependencies.map(callback)
-                  .concat(block.variables.map(function(variable) {
-                    return Promise.all(variable.dependencies.map(callback));
-                  }))
-                  .concat(block.blocks.map(function(block) {
-                    return walkDependencyBlock(block, callback);
-                  }))
-                );
-              };
-
-              var state = {state: {imports: {}}};
-
-              return walkDependencyBlock(cacheItem, function(cacheDependency) {
-                if (
-                  cacheDependency &&
-                  !cacheDependency.contextDependency &&
-                  typeof cacheDependency.request !== 'undefined'
-                ) {
-                  var resolveId = JSON.stringify(
-                    [cacheItem.context, cacheDependency.request]
-                  );
-                  var resolveItem = resolveCache[resolveId];
-                  if (
-                    resolveItem &&
-                    resolveItem.request &&
-                    resolveItem.resource &&
-                    fileTimestamps[resolveItem.resource.split('?')[0]]
-                  ) {
-                    var depIdentifier = identifierPrefix + resolveItem.request;
-                    var depCacheItem = moduleCache[depIdentifier];
-                    if (
-                      depCacheItem &&
-                      depCacheItem.fileDependencies
-                      .reduce(function(carry, file) {
-                        return carry && fileTimestamps[file];
-                      }, true) &&
-                      depCacheItem.contextDependencies
-                      .reduce(function(carry, dir) {
-                        return carry && contextTimestamps[dir];
-                      }, true)
-                    ) {
-                      return Promise.resolve();
-                    }
-                    else if (depCacheItem) {
-                      return Promise.reject();
-                    }
-                  }
-                }
-
-                if (cacheDependency.moduleIdentifier) {
-                  var dependency = deserializeDependencies.dependencies.call(state, [cacheDependency], null)[0];
-                  var factory = compilation.dependencyFactories.get(dependency.constructor);
-                  return new Promise(function(resolve, reject) {
-                    var callFactory = function(fn) {
-                      if (factory.create.length === 2) {
-                        factory.create({
-                          contextInfo: {
-                            issuer: cacheItem.resource.split('?')[0],
-                          },
-                          context: cacheItem.context,
-                          dependencies: [dependency],
-                        }, fn);
-                      }
-                      if (factory.create.length === 3) {
-                        factory.create(cacheItem.context, dependency, fn);
-                      }
-                    };
-                    callFactory(function(err, depModule) {
-                      if (err) {
-                        return reject(err);
-                      }
-                      if (cacheDependency.moduleIdentifier === depModule.identifier()) {
-                        return resolve();
-                      }
-                      reject(new Error('dependency has a new identifier'));
-                    });
-                  });
-                }
-
-                return Promise.resolve();
-              })
-              .then(function() {
-                // console.log('valid', cacheItem.request);
-                var module = new HardModule(cacheItem);
-
-                return cb(null, module);
-              })
-              .catch(function(err) {
-                // console.log('invalid', cacheItem.request, err);
-                cacheItem.invalid = true;
-                moduleCache[identifier] = null;
-
-                return cb(null, result);
-              });
-            }
+          else if (p) {
+            var module = new HardModule(p);
+            return cb(null, module);
           }
-          return cb(null, result);
+          cb(err, result);
         });
       };
     });
@@ -1076,6 +1161,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       }
 
       if (!lodash.isEqual(compilation.fileDependencies, dataCache.fileDependencies)) {
+        // console.log(compilation.fileDependencies);
         // dataCache.fileDependencies = (dataCache.fileDependencies || [])
         // .concat(fileDependenciesDiff);
         lodash.difference(dataCache.fileDependencies, compilation.fileDependencies).forEach(function(file) {
@@ -1167,15 +1253,15 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       });
     }
 
-    function serializeError(error) {
+    function serializeError(error, parent) {
       var serialized = {
         message: error.message,
       };
       if (error.origin) {
-        serialized.origin = serializeDependencies([error.origin])[0];
+        serialized.origin = serializeDependencies([error.origin], parent)[0];
       }
       if (error.dependencies) {
-        serialized.dependencies = serializeDependencies(error.dependencies);
+        serialized.dependencies = serializeDependencies(error.dependencies, parent);
       }
       return serialized;
     }
@@ -1241,9 +1327,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           baseMap: module.useSourceMap && source.map(),
           hashContent: serializeHashContent(module),
 
-          dependencies: serializeDependencies(module.dependencies),
-          variables: serializeVariables(module.variables),
-          blocks: serializeBlocks(module.blocks),
+          dependencies: serializeDependencies(module.dependencies, module),
+          variables: serializeVariables(module.variables, module),
+          blocks: serializeBlocks(module.blocks, module),
 
           fileDependencies: module.fileDependencies,
           contextDependencies: module.contextDependencies,
@@ -1327,9 +1413,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           baseMap: module.useSourceMap && source.map(),
           hashContent: serializeHashContent(module),
 
-          dependencies: serializeDependencies(module.dependencies),
-          variables: serializeVariables(module.variables),
-          blocks: serializeBlocks(module.blocks),
+          dependencies: serializeDependencies(module.dependencies, module),
+          variables: serializeVariables(module.variables, module),
+          blocks: serializeBlocks(module.blocks, module),
         };
 
         moduleOps.push({

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -168,4 +168,25 @@ describe('basic webpack use - builds changes', function() {
     expect(output.run2['main.js'].toString()).to.not.match(/exports = 12/);
   });
 
+  itCompilesChange('base-context-move', {
+    'vendor/a/1.js': 'module.exports = 1;',
+    'vendor/a/2.js': 'module.exports = 2;',
+    'vendor/a/3.js': 'module.exports = 3;',
+    'vendor/a/4.js': 'module.exports = 4;',
+    'vendor/a/5.js': 'module.exports = 5;',
+    'web_modules/a': null,
+  }, {
+    'web_modules/a/1.js': 'module.exports = 11;',
+    'web_modules/a/2.js': 'module.exports = 12;',
+    'web_modules/a/3.js': 'module.exports = 13;',
+    'web_modules/a/4.js': 'module.exports = 14;',
+    'web_modules/a/5.js': 'module.exports = 15;',
+    'vendor/a': null,
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/exports = 1;/);
+    expect(output.run1['main.js'].toString()).to.not.match(/exports = 11;/);
+    expect(output.run2['main.js'].toString()).to.match(/exports = 11;/);
+    expect(output.run2['main.js'].toString()).to.not.match(/exports = 1;/);
+  });
+
 });

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -23,6 +23,7 @@ describe('basic webpack use - compiles identically', function() {
   itCompilesTwice('base-amd-1dep');
   itCompilesTwice('base-amd-context');
   itCompilesTwice('base-amd-code-split');
+  itCompilesTwice('base-external');
 
 });
 
@@ -33,6 +34,7 @@ describe('basic webpack use - compiles hard modules', function() {
   itCompilesHardModules('base-deep-context', ['./a \\d']);
   itCompilesHardModules('base-code-split', ['./fib.js', './index.js']);
   itCompilesHardModules('base-query-request', ['./fib.js?argument']);
+  itCompilesHardModules('base-external', ['./index.js']);
 
 });
 

--- a/tests/base-webpack-2.js
+++ b/tests/base-webpack-2.js
@@ -87,6 +87,37 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     expect(output.run2['main.js'].toString()).to.contain('console.log(__WEBPACK_IMPORTED_MODULE_0__obj__["b" /* fib */], __WEBPACK_IMPORTED_MODULE_0__obj__["a" /* key */]);');
   });
 
+  itCompilesChange('base-change-es2015-export-order-module', {
+    'other.js': [
+      'import {fib, key} from \'./obj\';',
+      'console.log(fib);',
+      'console.log(key);',
+    ].join('\n'),
+    'obj.js': [
+      'import \'./other\';',
+      'export function fib(n) {',
+      '  return n + (n > 0 ? n - 1 : 0);',
+      '}',
+      'export let key = \'obj\';',
+    ].join('\n'),
+  }, {
+    'other.js': [
+      'import {fib, key} from \'./obj\';',
+      'console.log(key);',
+      'console.log(fib);',
+    ].join('\n'),
+    'obj.js': [
+      'import \'./other\';',
+      'export let key = \'obj\';',
+      'export function fib(n) {',
+      '  return n + (n > 0 ? n - 1 : 0);',
+      '}',
+    ].join('\n'),
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.contain('console.log(__WEBPACK_IMPORTED_MODULE_0__obj__["a" /* fib */], __WEBPACK_IMPORTED_MODULE_0__obj__["b" /* key */]);');
+    expect(output.run2['main.js'].toString()).to.contain('console.log(__WEBPACK_IMPORTED_MODULE_0__obj__["b" /* fib */], __WEBPACK_IMPORTED_MODULE_0__obj__["a" /* key */]);');
+  });
+
   itCompilesChange('base-change-es2015-all-module', {
     'index.js': [
       'import {key} from \'./obj\';',

--- a/tests/fixtures/base-change-es2015-export-order-module/obj.js
+++ b/tests/fixtures/base-change-es2015-export-order-module/obj.js
@@ -1,5 +1,5 @@
 import './other';
+export let key = 'obj';
 export function fib(n) {
   return n + (n > 0 ? n - 1 : 0);
 }
-export let key = 'obj';

--- a/tests/fixtures/base-context-move/a.js
+++ b/tests/fixtures/base-context-move/a.js
@@ -1,0 +1,8 @@
+var context = require.context('a', true, /\d/);
+
+module.exports =
+  context('./1') +
+  context('./2') +
+  context('./3') +
+  context('./4') +
+  context('./5');

--- a/tests/fixtures/base-context-move/b/10.js
+++ b/tests/fixtures/base-context-move/b/10.js
@@ -1,0 +1,1 @@
+module.exports = 10;

--- a/tests/fixtures/base-context-move/b/6.js
+++ b/tests/fixtures/base-context-move/b/6.js
@@ -1,0 +1,1 @@
+module.exports = 6;

--- a/tests/fixtures/base-context-move/b/7.js
+++ b/tests/fixtures/base-context-move/b/7.js
@@ -1,0 +1,1 @@
+module.exports = 7;

--- a/tests/fixtures/base-context-move/b/8.js
+++ b/tests/fixtures/base-context-move/b/8.js
@@ -1,0 +1,1 @@
+module.exports = 8;

--- a/tests/fixtures/base-context-move/b/9.js
+++ b/tests/fixtures/base-context-move/b/9.js
@@ -1,0 +1,1 @@
+module.exports = 9;

--- a/tests/fixtures/base-context-move/b/index.js
+++ b/tests/fixtures/base-context-move/b/index.js
@@ -1,0 +1,6 @@
+module.exports =
+  require('./6') +
+  require('./7') +
+  require('./8') +
+  require('./9') +
+  require('./10');

--- a/tests/fixtures/base-context-move/index.js
+++ b/tests/fixtures/base-context-move/index.js
@@ -1,0 +1,1 @@
+console.log(require('./a') + require('./b'));

--- a/tests/fixtures/base-context-move/web_modules/a/1.js
+++ b/tests/fixtures/base-context-move/web_modules/a/1.js
@@ -1,0 +1,1 @@
+module.exports = 11;

--- a/tests/fixtures/base-context-move/web_modules/a/2.js
+++ b/tests/fixtures/base-context-move/web_modules/a/2.js
@@ -1,0 +1,1 @@
+module.exports = 12;

--- a/tests/fixtures/base-context-move/web_modules/a/3.js
+++ b/tests/fixtures/base-context-move/web_modules/a/3.js
@@ -1,0 +1,1 @@
+module.exports = 13;

--- a/tests/fixtures/base-context-move/web_modules/a/4.js
+++ b/tests/fixtures/base-context-move/web_modules/a/4.js
@@ -1,0 +1,1 @@
+module.exports = 14;

--- a/tests/fixtures/base-context-move/web_modules/a/5.js
+++ b/tests/fixtures/base-context-move/web_modules/a/5.js
@@ -1,0 +1,1 @@
+module.exports = 15;

--- a/tests/fixtures/base-context-move/webpack.config.js
+++ b/tests/fixtures/base-context-move/webpack.config.js
@@ -1,0 +1,45 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+var ifWebpack1 = function(obj) {
+  if (require('webpack/package.json').version[0] === '1') {
+    return obj;
+  }
+};
+
+var ifWebpack2 = function(obj) {
+  if (require('webpack/package.json').version[0] === '2') {
+    return obj;
+  }
+};
+
+var removeEmptyValues = function(obj) {
+  var _obj = {};
+  for (var key in obj) {
+    if (obj[key]) {
+      _obj[key] = obj[key];
+    }
+  }
+  return _obj;
+};
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  resolve: removeEmptyValues({
+    modulesDirectories: ifWebpack1(['node_modules', 'vendor', 'web_modules']),
+    modules: ifWebpack2(['node_modules', 'vendor', 'web_modules']),
+  }),
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/base-external/index.js
+++ b/tests/fixtures/base-external/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/base-external/webpack.config.js
+++ b/tests/fixtures/base-external/webpack.config.js
@@ -1,0 +1,23 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  externals: function(context, request, cb) {
+    if (request === './fib') {return cb(null, './fib', 'commonjs2');}
+    cb();
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/loader-custom-no-dep-moved/index.js
+++ b/tests/fixtures/loader-custom-no-dep-moved/index.js
@@ -1,0 +1,1 @@
+require('./loader.js!./fib');

--- a/tests/fixtures/loader-custom-no-dep-moved/loader.js
+++ b/tests/fixtures/loader-custom-no-dep-moved/loader.js
@@ -1,0 +1,9 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(source) {};
+
+module.exports.pitch = function(remainingRequest) {
+  this.cacheable && this.cacheable();
+  return '// ' + remainingRequest;
+};

--- a/tests/fixtures/loader-custom-no-dep-moved/webpack.config.js
+++ b/tests/fixtures/loader-custom-no-dep-moved/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/loader-custom-no-dep/index.js
+++ b/tests/fixtures/loader-custom-no-dep/index.js
@@ -1,0 +1,1 @@
+require('./loader.js!./fib.js');

--- a/tests/fixtures/loader-custom-no-dep/loader.js
+++ b/tests/fixtures/loader-custom-no-dep/loader.js
@@ -1,0 +1,9 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(source) {};
+
+module.exports.pitch = function() {
+  this.cacheable && this.cacheable();
+  return '// no source';
+};

--- a/tests/fixtures/loader-custom-no-dep/webpack.config.js
+++ b/tests/fixtures/loader-custom-no-dep/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/plugin-dll-reference-scope/dll-manifest.json
+++ b/tests/fixtures/plugin-dll-reference-scope/dll-manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "dll_c640cf83e777b7d462d5",
+  "content": {
+    "./fib.js": {
+      "id": 0,
+      "meta": {},
+      "hasStarExport": false,
+      "activeExports": []
+    }
+  }
+}

--- a/tests/fixtures/plugin-dll-reference-scope/dll.js
+++ b/tests/fixtures/plugin-dll-reference-scope/dll.js
@@ -1,0 +1,84 @@
+var dll_c640cf83e777b7d462d5 =
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmory imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmory exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		Object.defineProperty(exports, name, {
+/******/ 			configurable: false,
+/******/ 			enumerable: true,
+/******/ 			get: getter
+/******/ 		});
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__;
+
+/***/ }
+/******/ ]);

--- a/tests/fixtures/plugin-dll-reference-scope/fib.js
+++ b/tests/fixtures/plugin-dll-reference-scope/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/plugin-dll-reference-scope/index.js
+++ b/tests/fixtures/plugin-dll-reference-scope/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/plugin-dll-reference-scope/webpack.config.js
+++ b/tests/fixtures/plugin-dll-reference-scope/webpack.config.js
@@ -1,14 +1,12 @@
-var DllPlugin = require('webpack').DllPlugin;
+var DllReferencePlugin = require('webpack').DllReferencePlugin;
 var HardSourceWebpackPlugin = require('../../..');
 
 module.exports = {
   context: __dirname,
-  entry: {
-    'dll': ['./fib.js'],
-  },
+  entry: './index.js',
   output: {
     path: __dirname + '/tmp',
-    filename: 'dll.js',
+    filename: 'main.js',
     library: '[name]_[hash]',
   },
   recordsPath: __dirname + '/tmp/cache/records.json',
@@ -19,10 +17,11 @@ module.exports = {
         root: __dirname + '/../../..',
       },
     }),
-    new DllPlugin({
-      path: __dirname + '/tmp/dll-manifest.json',
-      name: '[name]_[hash]',
-      context: __dirname,
+    new DllReferencePlugin({
+      scope: '.',
+      extensions: ['', '.js'],
+      manifest: require('./dll-manifest.json'),
+      // manifest: __dirname + '/dll-manifest.json',
     }),
   ],
 };

--- a/tests/fixtures/plugin-dll-reference/webpack.config.js
+++ b/tests/fixtures/plugin-dll-reference/webpack.config.js
@@ -19,7 +19,6 @@ module.exports = {
     }),
     new DllReferencePlugin({
       manifest: require('./dll-manifest.json'),
-      context: __dirname,
     }),
   ],
 };

--- a/tests/fixtures/plugin-dll-reference/webpack.config.js
+++ b/tests/fixtures/plugin-dll-reference/webpack.config.js
@@ -18,7 +18,9 @@ module.exports = {
       },
     }),
     new DllReferencePlugin({
+      context: __dirname,
       manifest: require('./dll-manifest.json'),
+      // manifest: __dirname + '/dll-manifest.json',
     }),
   ],
 };

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -12,10 +12,12 @@ describe('loader webpack use', function() {
   itCompilesTwice('loader-css');
   itCompilesTwice('loader-file');
   itCompilesTwice('loader-custom-missing-dep');
+  itCompilesTwice('loader-custom-no-dep');
 
   itCompilesHardModules('loader-css', ['./index.css']);
   itCompilesHardModules('loader-file', ['./image.png']);
   itCompilesHardModules('loader-custom-user-loader', ['./loader.js!./index.js']);
+  itCompilesHardModules('loader-custom-no-dep', ['./index.js', './loader.js!./fib.js']);
 
 });
 
@@ -114,6 +116,19 @@ describe('loader webpack use - builds changes', function() {
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.match(/n - 1/);
     expect(output.run2['main.js'].toString()).to.not.match(/n - 1/);
+  });
+
+  itCompilesChange('loader-custom-no-dep-moved', {
+    'fib.js': '',
+    'fib/index.js': null,
+  }, {
+    'fib.js': null,
+    'fib/index.js': '',
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/fib\.js/);
+    expect(output.run1['main.js'].toString()).to.not.match(/fib\/index\.js/);
+    expect(output.run2['main.js'].toString()).to.match(/fib\/index\.js/);
+    expect(output.run2['main.js'].toString()).to.not.match(/fib\.js/);
   });
 
 });

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -24,6 +24,7 @@ describe('plugin webpack use', function() {
   itCompilesTwice('plugin-hmr-accept-dep', {exportStats: true});
   itCompilesTwice('plugin-hmr-process-env', {exportStats: true});
 
+  itCompilesHardModules('plugin-dll-reference', ['./index.js']);
   itCompilesHardModules('plugin-html-lodash', [/lodash\/lodash\.js$/, /\!\.\/index\.html$/]);
 
 });

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -10,6 +10,7 @@ describe('plugin webpack use', function() {
 
   itCompilesTwice('plugin-dll');
   itCompilesTwice('plugin-dll-reference');
+  itCompilesTwice('plugin-dll-reference-scope');
   itCompilesTwice('plugin-html-lodash');
   itCompilesTwice('plugin-extract-text');
   itCompilesTwice('plugin-extract-text-loader-file');
@@ -24,7 +25,9 @@ describe('plugin webpack use', function() {
   itCompilesTwice('plugin-hmr-accept-dep', {exportStats: true});
   itCompilesTwice('plugin-hmr-process-env', {exportStats: true});
 
+  itCompilesHardModules('plugin-dll', ['./fib.js']);
   itCompilesHardModules('plugin-dll-reference', ['./index.js']);
+  itCompilesHardModules('plugin-dll-reference-scope', ['./index.js']);
   itCompilesHardModules('plugin-html-lodash', [/lodash\/lodash\.js$/, /\!\.\/index\.html$/]);
 
 });


### PR DESCRIPTION
Fix #18

DelegatedModules are used by the DllReferencePlugin to refer to modules in a DLL packaged with webpack and the DllPlugin. Currently modules depending on a DelegatedModule are invalidated since HardSource can't map the dependendency to the not yet cached DelegatedModule.