### PR TITLE
Support webpack 2 beta's HarmonyCompatibility dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ node_js:
 env:
   matrix:
     - WEBPACK_VERSION=1.13.1
-    - WEBPACK_VERSION=2.1.0-beta.25 EXTRACT_TEXT_VERSION=2.0.0-beta.4
+    - WEBPACK_VERSION=2.1.0-beta.28 EXTRACT_TEXT_VERSION=2.0.0-beta.4
 matrix:
   fast_finish: true
   allow_failures:
-    - env: WEBPACK_VERSION=2.1.0-beta.25 EXTRACT_TEXT_VERSION=2.0.0-beta.4
+    - env: WEBPACK_VERSION=2.1.0-beta.28 EXTRACT_TEXT_VERSION=2.0.0-beta.4
 before_script:
   - npm rm webpack extract-text-webpack-plugin
   - npm install webpack@$WEBPACK_VERSION extract-text-webpack-plugin@$EXTRACT_TEXT_VERSION

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ function serializeDependencies(deps, parent) {
         };
       }
     }
-    if (!cacheDep && dep.originModule) {
+    if (!cacheDep && dep.originModule && dep.describeHarmonyExport) {
       cacheDep = {
         harmonyExport: true,
         harmonyId: dep.id,

--- a/tests/base-webpack-2.js
+++ b/tests/base-webpack-2.js
@@ -1,17 +1,31 @@
 var expect = require('chai').expect;
 
+var itCompiles = require('./util').itCompiles;
 var itCompilesTwice = require('./util').itCompilesTwice;
 var itCompilesChange = require('./util').itCompilesChange;
+var itCompilesHardModules = require('./util').itCompilesHardModules;
 var describeWP2 = require('./util').describeWP2;
 
 describeWP2('basic webpack 2 use - compiles identically', function() {
 
   itCompilesTwice('base-es2015-module');
+  itCompilesTwice('base-es2015-module-compatibility');
   itCompilesTwice('base-es2015-rename-module');
   itCompilesTwice('base-es2015-system-context');
   itCompilesTwice('base-es2015-system-module');
   itCompilesTwice('base-warning-context');
   itCompilesTwice('base-warning-es2015');
+
+  itCompilesHardModules('base-es2015-module', ['./index.js', './obj.js', './fib.js']);
+  itCompilesHardModules('base-es2015-module-compatibility', ['./index.js', './obj.js', './fib.js']);
+
+  itCompiles(
+    'it includes compatibility dependency in base-es2015-module-compatibility', 
+    'base-es2015-module-compatibility',
+    function(output) {
+      expect(output.run2['main.js'].toString()).to.contain('__esModule');
+    }
+  );
 
 });
 

--- a/tests/fixtures/base-change-es2015-commonjs-module/index.js
+++ b/tests/fixtures/base-change-es2015-commonjs-module/index.js
@@ -1,2 +1,2 @@
-var fib = require('./obj').fib;
-console.log(fib(3));
+import {key} from './obj';
+console.log(key);

--- a/tests/fixtures/base-change-es2015-export-order-module/other.js
+++ b/tests/fixtures/base-change-es2015-export-order-module/other.js
@@ -1,3 +1,3 @@
 import {fib, key} from './obj';
-console.log(key);
 console.log(fib);
+console.log(key);

--- a/tests/fixtures/base-es2015-module-compatibility/fib.js
+++ b/tests/fixtures/base-es2015-module-compatibility/fib.js
@@ -1,0 +1,3 @@
+export default function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-es2015-module-compatibility/index.js
+++ b/tests/fixtures/base-es2015-module-compatibility/index.js
@@ -1,0 +1,3 @@
+import * as fib from './obj';
+
+console.log(fib(3));

--- a/tests/fixtures/base-es2015-module-compatibility/obj.js
+++ b/tests/fixtures/base-es2015-module-compatibility/obj.js
@@ -1,0 +1,3 @@
+import fib from './fib';
+let key = 'obj';
+export {key, fib};

--- a/tests/fixtures/base-es2015-module-compatibility/webpack.config.js
+++ b/tests/fixtures/base-es2015-module-compatibility/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -173,6 +173,22 @@ exports.readFiles = function(outputPath) {
 };
 
 exports.itCompiles = function(name, fixturePath, fnA, fnB, expectHandle) {
+  if (!fnA) {
+    expectHandle = fixturePath;
+    fixturePath = name;
+    fnB = function() {};
+    fnA = function() {};
+  }
+  if (!fnB) {
+    expectHandle = fnA;
+    fnB = function() {};
+    fnA = function() {};
+  }
+  if (!expectHandle) {
+    expectHandle = fnB;
+    fnB = fnA;
+  }
+
   before(function() {
     return exports.clean(fixturePath);
   });


### PR DESCRIPTION
Fix #73

webpack 2 beta adds a HarmonyCompatibilty dependency to every module
that using harmony module syntax. This dependency like export
dependencies has an originModule but it does not have a
describeHarmonyExport method. This type of dependency can be safely
ignored like other NullDependencies.