### PR TITLE
Deserialize importDependency for import specifiers

### DIFF
--- a/lib/deserialize-dependencies.js
+++ b/lib/deserialize-dependencies.js
@@ -37,6 +37,9 @@ function deserializeDependencies(deps, parent) {
       return this.state.imports[req.request] = new HardHarmonyImportDependency(req.request);
     }
     if (req.harmonyImportSpecifier) {
+      if (!this.state.imports[req.harmonyRequest]) {
+        this.state.imports[req.harmonyRequest] = new HardHarmonyImportDependency(req.harmonyRequest);
+      }
       var dep = new HardHarmonyImportSpecifierDependency(this.state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
       dep.loc = req.loc;
       return dep;

--- a/tests/base-webpack-2.js
+++ b/tests/base-webpack-2.js
@@ -10,6 +10,8 @@ describeWP2('basic webpack 2 use - compiles identically', function() {
 
   itCompilesTwice('base-es2015-module');
   itCompilesTwice('base-es2015-module-compatibility');
+  itCompilesTwice('base-es2015-module-export-before-import');
+  itCompilesTwice('base-es2015-module-use-before-import');
   itCompilesTwice('base-es2015-rename-module');
   itCompilesTwice('base-es2015-system-context');
   itCompilesTwice('base-es2015-system-module');
@@ -18,6 +20,8 @@ describeWP2('basic webpack 2 use - compiles identically', function() {
 
   itCompilesHardModules('base-es2015-module', ['./index.js', './obj.js', './fib.js']);
   itCompilesHardModules('base-es2015-module-compatibility', ['./index.js', './obj.js', './fib.js']);
+  itCompilesHardModules('base-es2015-module-export-before-import', ['./index.js', './obj.js', './fib.js']);
+  itCompilesHardModules('base-es2015-module-use-before-import', ['./index.js', './obj.js', './fib.js']);
 
   itCompiles(
     'it includes compatibility dependency in base-es2015-module-compatibility', 

--- a/tests/fixtures/base-es2015-module-use-before-import/fib.js
+++ b/tests/fixtures/base-es2015-module-use-before-import/fib.js
@@ -1,0 +1,3 @@
+export default function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-es2015-module-use-before-import/index.js
+++ b/tests/fixtures/base-es2015-module-use-before-import/index.js
@@ -1,0 +1,2 @@
+console.log(key(3));
+import {key} from './obj';

--- a/tests/fixtures/base-es2015-module-use-before-import/obj.js
+++ b/tests/fixtures/base-es2015-module-use-before-import/obj.js
@@ -1,0 +1,3 @@
+import fib from './fib';
+let key = 'obj';
+export {key, fib};

--- a/tests/fixtures/base-es2015-module-use-before-import/webpack.config.js
+++ b/tests/fixtures/base-es2015-module-use-before-import/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Related to #79

Import specifiers like export specifiers are allowed by webpack to
appear before their corresponding import. In that case create an import
dependency for them before that.

- Test against this regressing