### PR TITLE
Support webpack 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ node_js:
 env:
   matrix:
     - WEBPACK_VERSION=1.13.1
-    - WEBPACK_VERSION=2.2.0-rc.1 EXTRACT_TEXT_VERSION=2.0.0-beta.4
+    - WEBPACK_VERSION=2.2.0 EXTRACT_TEXT_VERSION=2.0.0-beta.5
 matrix:
   fast_finish: true
   allow_failures:
     - node_js: "4"
-      env: WEBPACK_VERSION=2.2.0-rc.1 EXTRACT_TEXT_VERSION=2.0.0-beta.4
+      env: WEBPACK_VERSION=2.2.0 EXTRACT_TEXT_VERSION=2.0.0-beta.5
 before_script:
   - npm rm webpack extract-text-webpack-plugin
   - npm install webpack@$WEBPACK_VERSION extract-text-webpack-plugin@$EXTRACT_TEXT_VERSION

--- a/index.js
+++ b/index.js
@@ -1334,6 +1334,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           meta: module.meta,
           used: module.used,
           usedExports: module.usedExports,
+          // HarmonyDetectionParserPlugin
+          exportsArgument: module.exportsArgument,
           issuer:
             typeof module.issuer === 'string' ? module.issuer :
             module.issuer && typeof module.issuer === 'object' ? module.issuer.identifier() :

--- a/index.js
+++ b/index.js
@@ -38,15 +38,22 @@ try{
 }
 var NullFactory = require('webpack/lib/NullFactory');
 
-var HarmonyImportDependency, HarmonyImportSpecifierDependency, HarmonyExportImportedSpecifierDependency, SystemImportContextDependency;
+var HarmonyCompatiblilityDependency;
+var HarmonyExportImportedSpecifierDependency;
+var HarmonyImportDependency;
+var HarmonyImportSpecifierDependency;
+var ImportContextDependency;
 
 try {
+  HarmonyCompatiblilityDependency = require('webpack/lib/dependencies/HarmonyCompatiblilityDependency');
+  HarmonyExportImportedSpecifierDependency = require('webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency');
   HarmonyImportDependency = require('webpack/lib/dependencies/HarmonyImportDependency');
   HarmonyImportSpecifierDependency = require('webpack/lib/dependencies/HarmonyImportSpecifierDependency');
-  HarmonyExportImportedSpecifierDependency = require('webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency');
-  SystemImportContextDependency = require('webpack/lib/dependencies/SystemImportContextDependency');
+  ImportContextDependency = require('webpack/lib/dependencies/ImportContextDependency');
 }
-catch (_) {}
+catch (_) {
+  HarmonyCompatiblilityDependency = function() {};
+}
 
 var HardModuleDependency = require('./lib/dependencies').HardModuleDependency;
 var HardContextDependency = require('./lib/dependencies').HardContextDependency;
@@ -57,6 +64,7 @@ require('./lib/dependencies').HardHarmonyImportDependency;
 var HardHarmonyImportSpecifierDependency =
 require('./lib/dependencies').HardHarmonyImportSpecifierDependency;
 var HardHarmonyExportImportedSpecifierDependency = require('./lib/dependencies').HardHarmonyExportImportedSpecifierDependency;
+var HardHarmonyCompatiblilityDependency = require('./lib/dependencies').HardHarmonyCompatiblilityDependency;
 
 var FileSerializer = require('./lib/cache-serializers').FileSerializer;
 var LevelDbSerializer = require('./lib/cache-serializers').LevelDbSerializer;
@@ -126,6 +134,11 @@ function serializeDependencies(deps, parent) {
           loc: flattenPrototype(dep.loc),
         };
       }
+      else if (dep instanceof HarmonyCompatiblilityDependency) {
+        cacheDep = {
+          harmonyCompatibility: true,
+        };
+      }
     }
     if (!cacheDep && dep.originModule && dep.describeHarmonyExport) {
       cacheDep = {
@@ -165,7 +178,12 @@ function serializeDependencies(deps, parent) {
     return cacheDep;
   })
   .filter(function(req) {
-    return req.request || req.constDependency || req.harmonyExport || req.harmonyImportSpecifier || req.harmonyExportImportedSpecifier;
+    return req.request ||
+      req.constDependency ||
+      req.harmonyExport ||
+      req.harmonyImportSpecifier ||
+      req.harmonyExportImportedSpecifier ||
+      req.harmonyCompatibility;
   });
 }
 function serializeVariables(vars, parent) {
@@ -642,8 +660,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       factories.set(RequireContextDependency, hardContextFactory);
       factories.set(RequireResolveContextDependency, hardContextFactory);
 
-      if (SystemImportContextDependency) {
-        factories.set(SystemImportContextDependency, hardContextFactory);
+      if (ImportContextDependency) {
+        factories.set(ImportContextDependency, hardContextFactory);
       }
 
       factories.set(HardContextDependency, hardContextFactory);
@@ -856,6 +874,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
 
     compilation.dependencyFactories.set(HardHarmonyImportSpecifierDependency, new NullFactory());
     compilation.dependencyTemplates.set(HardHarmonyImportSpecifierDependency, new NullDependencyTemplate);
+
+    compilation.dependencyFactories.set(HardHarmonyCompatiblilityDependency, new NullFactory());
+    compilation.dependencyTemplates.set(HardHarmonyCompatiblilityDependency, new NullDependencyTemplate);
 
     compilation.dependencyFactories.set(HardHarmonyExportImportedSpecifierDependency, new NullFactory());
     compilation.dependencyTemplates.set(HardHarmonyExportImportedSpecifierDependency, new NullDependencyTemplate);

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -8,11 +8,12 @@ try {
 }
 catch (_) {}
 
-var HarmonyModulesHelpers, HarmonyImportSpecifierDependency, HarmonyExportImportedSpecifierDependency;
+var HarmonyModulesHelpers, HarmonyImportSpecifierDependency, HarmonyExportImportedSpecifierDependency, HarmonyCompatiblilityDependency;
 try {
   HarmonyModulesHelpers = require("webpack/lib/dependencies/HarmonyModulesHelpers");
   HarmonyImportSpecifierDependency = require('webpack/lib/dependencies/HarmonyImportSpecifierDependency');
   HarmonyExportImportedSpecifierDependency = require('webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency');
+  HarmonyCompatiblilityDependency = require('webpack/lib/dependencies/HarmonyCompatiblilityDependency');
 }
 catch (_) {}
 
@@ -24,19 +25,30 @@ module.exports = {
   HardHarmonyImportDependency: HardHarmonyImportDependency,
   HardHarmonyImportSpecifierDependency: HardHarmonyImportSpecifierDependency,
   HardHarmonyExportImportedSpecifierDependency: HardHarmonyExportImportedSpecifierDependency,
+  HardHarmonyCompatiblilityDependency: HardHarmonyCompatiblilityDependency,
 };
 
 function HardModuleDependency(request) {
-  ModuleDependency.call(this, request);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new ModuleDependency(request),
+      HardModuleDependency.prototype
+    )
+  );
 }
-HardModuleDependency.prototype = Object.create(ModuleDependency.prototype);
-HardModuleDependency.prototype.constructor = HardModuleDependency;
+Object.setPrototypeOf(HardModuleDependency.prototype, ModuleDependency.prototype);
+Object.setPrototypeOf(HardModuleDependency, ModuleDependency);
 
 function HardContextDependency(request, recursive, regExp) {
-  ContextDependency.call(this, request, recursive, regExp);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new ContextDependency(request, recursive, regExp),
+      HardContextDependency.prototype
+    )
+  );
 }
-HardContextDependency.prototype = Object.create(ContextDependency.prototype);
-HardContextDependency.prototype.constructor = HardContextDependency;
+Object.setPrototypeOf(HardContextDependency.prototype, ContextDependency.prototype);
+Object.setPrototypeOf(HardContextDependency, ContextDependency);
 
 if (CriticalDependencyWarning) {
   HardContextDependency.prototype.getWarnings = function() {
@@ -49,10 +61,15 @@ if (CriticalDependencyWarning) {
 }
 
 function HardNullDependency() {
-  NullDependency.call(this);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new NullDependency(),
+      HardNullDependency.prototype
+    )
+  );
 }
-HardNullDependency.prototype = Object.create(NullDependency.prototype);
-HardNullDependency.prototype.constructor = HardNullDependency;
+Object.setPrototypeOf(HardNullDependency.prototype, NullDependency.prototype);
+Object.setPrototypeOf(HardNullDependency, NullDependency);
 
 function HardModuleDependencyTemplate() {
 }
@@ -60,14 +77,19 @@ HardModuleDependencyTemplate.prototype.apply = function() {};
 HardModuleDependencyTemplate.prototype.applyAsTemplateArgument = function() {};
 
 function HardHarmonyExportDependency(originModule, id, name, precedence) {
-  NullDependency.call(this);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new NullDependency(),
+      HardHarmonyExportDependency.prototype
+    )
+  );
   this.originModule = originModule;
   this.id = id;
   this.name = name;
   this.precedence = precedence;
 }
-HardHarmonyExportDependency.prototype = Object.create(NullDependency.prototype);
-HardHarmonyExportDependency.prototype.constructor = HardHarmonyExportDependency;
+Object.setPrototypeOf(HardHarmonyExportDependency.prototype, NullDependency.prototype);
+Object.setPrototypeOf(HardHarmonyExportDependency, NullDependency);
 
 HardHarmonyExportDependency.prototype.getExports = function() {
   return {
@@ -83,10 +105,15 @@ HardHarmonyExportDependency.prototype.describeHarmonyExport = function() {
 };
 
 function HardHarmonyImportDependency(request) {
-  ModuleDependency.call(this, request);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new ModuleDependency(request),
+      HardHarmonyImportDependency.prototype
+    )
+  );
 }
-HardHarmonyImportDependency.prototype = Object.create(ModuleDependency.prototype);
-HardHarmonyImportDependency.prototype.constructor = HardHarmonyImportDependency;
+Object.setPrototypeOf(HardHarmonyImportDependency.prototype, ModuleDependency.prototype);
+Object.setPrototypeOf(HardHarmonyImportDependency, ModuleDependency);
 HardHarmonyImportDependency.prototype.getReference = function() {
   if(!this.module) return null;
   return {
@@ -96,19 +123,43 @@ HardHarmonyImportDependency.prototype.getReference = function() {
 };
 
 function HardHarmonyImportSpecifierDependency(importDependency, id, name) {
-  HarmonyImportSpecifierDependency.call(this, importDependency, null, id, name, null);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new HarmonyImportSpecifierDependency(importDependency, null, id, name, null),
+      HardHarmonyImportSpecifierDependency.prototype
+    )
+  );
 }
 
 if (typeof HarmonyImportSpecifierDependency !== 'undefined') {
-  HardHarmonyImportSpecifierDependency.prototype = Object.create(HarmonyImportSpecifierDependency.prototype);
-  HardHarmonyImportSpecifierDependency.prototype.constructor = HardHarmonyImportSpecifierDependency;
+  Object.setPrototypeOf(HardHarmonyImportSpecifierDependency.prototype, HarmonyImportSpecifierDependency.prototype);
+  Object.setPrototypeOf(HardHarmonyImportSpecifierDependency, HarmonyImportSpecifierDependency);
 }
 
 function HardHarmonyExportImportedSpecifierDependency(originModule, importDependency, id, name) {
-  HarmonyExportImportedSpecifierDependency.call(this, originModule, importDependency, null, id, name, null);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new HarmonyExportImportedSpecifierDependency(originModule, importDependency, null, id, name, null),
+      HardHarmonyExportImportedSpecifierDependency.prototype
+    )
+  );
 }
 
 if (typeof HarmonyExportImportedSpecifierDependency !== 'undefined') {
-  HardHarmonyExportImportedSpecifierDependency.prototype = Object.create(HarmonyExportImportedSpecifierDependency.prototype);
-  HardHarmonyExportImportedSpecifierDependency.prototype.constructor = HardHarmonyExportImportedSpecifierDependency;
+  Object.setPrototypeOf(HardHarmonyExportImportedSpecifierDependency.prototype, HarmonyExportImportedSpecifierDependency.prototype);
+  Object.setPrototypeOf(HardHarmonyExportImportedSpecifierDependency, HarmonyExportImportedSpecifierDependency);
+}
+
+function HardHarmonyCompatiblilityDependency(originModule) {
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new HarmonyCompatiblilityDependency(originModule),
+      HardHarmonyCompatiblilityDependency.prototype
+    )
+  );
+}
+
+if (typeof HarmonyCompatiblilityDependency !== 'undefined') {
+  Object.setPrototypeOf(HardHarmonyCompatiblilityDependency.prototype, HarmonyCompatiblilityDependency.prototype);
+  Object.setPrototypeOf(HardHarmonyCompatiblilityDependency, HarmonyCompatiblilityDependency);
 }

--- a/lib/deserialize-dependencies.js
+++ b/lib/deserialize-dependencies.js
@@ -10,6 +10,7 @@ require('./dependencies').HardHarmonyImportDependency;
 var HardHarmonyImportSpecifierDependency =
 require('./dependencies').HardHarmonyImportSpecifierDependency;
 var HardHarmonyExportImportedSpecifierDependency = require('./dependencies').HardHarmonyExportImportedSpecifierDependency;
+var HardHarmonyCompatiblilityDependency = require('./dependencies').HardHarmonyCompatiblilityDependency;
 
 exports.dependencies = deserializeDependencies;
 exports.variables = deserializeVariables;
@@ -49,6 +50,9 @@ function deserializeDependencies(deps, parent) {
         this.state.imports[req.harmonyRequest] = new HardHarmonyImportDependency(req.harmonyRequest);
       }
       return new HardHarmonyExportImportedSpecifierDependency(parent, this.state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
+    }
+    if (req.harmonyCompatibility) {
+      return new HardHarmonyCompatiblilityDependency(parent);
     }
     var dep = new HardModuleDependency(req.request);
     dep.loc = req.loc;

--- a/lib/hard-context-module.js
+++ b/lib/hard-context-module.js
@@ -8,7 +8,12 @@ var deserializeDependencies = require('./deserialize-dependencies');
 module.exports = HardContextModule;
 
 function HardContextModule(cacheItem) {
-  RawModule.call(this, cacheItem.source, cacheItem.identifier, cacheItem.context);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new ContextModule(cacheItem.source, cacheItem.identifier, cacheItem.context),
+      HardContextModule.prototype
+    )
+  );
   this.cacheItem = cacheItem;
   this.context = cacheItem.context;
   this.recursive = cacheItem.recursive;
@@ -20,8 +25,8 @@ function HardContextModule(cacheItem) {
   this.built = false;
 }
 
-HardContextModule.prototype = Object.create(RawModule.prototype);
-HardContextModule.prototype.constructor = HardContextModule;
+Object.setPrototypeOf(HardContextModule.prototype, ContextModule.prototype);
+Object.setPrototypeOf(HardContextModule, ContextModule);
 
 HardContextModule.prototype.isHard = function() {return true;};
 

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -15,7 +15,12 @@ var HardSource = require('./hard-source');
 module.exports = HardModule;
 
 function HardModule(cacheItem) {
-  RawModule.call(this, cacheItem.source, cacheItem.identifier, cacheItem.userRequest);
+  Object.setPrototypeOf(this,
+    Object.setPrototypeOf(
+      new RawModule(cacheItem.source, cacheItem.identifier, cacheItem.userRequest),
+      HardModule.prototype
+    )
+  );
 
   this.cacheItem = cacheItem;
 
@@ -27,13 +32,14 @@ function HardModule(cacheItem) {
   this.loaders = cacheItem.loaders;
 
   this.strict = cacheItem.strict;
+  this.exportsArgument = cacheItem.exportsArgument;
   this.meta = cacheItem.meta;
   this.buildTimestamp = cacheItem.buildTimestamp;
   this.fileDependencies = cacheItem.fileDependencies;
   this.contextDependencies = cacheItem.contextDependencies;
 }
-HardModule.prototype = Object.create(RawModule.prototype);
-HardModule.prototype.constructor = HardModule;
+Object.setPrototypeOf(HardModule.prototype, RawModule.prototype);
+Object.setPrototypeOf(HardModule, RawModule);
 
 HardModule.prototype.isHard = function() {return true;};
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "css-loader": "^0.26.1",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^1.0.1 || ^2.0.0-beta",
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.22.0",
     "memory-fs": "^0.4.1",
@@ -37,7 +37,7 @@
     "webpack-isomorphic-tools": "^2.5.7"
   },
   "peerDependencies": {
-    "webpack": ">=1.13.1 || ^2.1.0-beta || ^2.2.0-rc"
+    "webpack": ">=1.13.1 || ^2.1.0-beta || ^2.2.0-rc || ^2.2.0"
   },
   "dependencies": {
     "bluebird": "^3.0.0",

--- a/tests/base-webpack-2.js
+++ b/tests/base-webpack-2.js
@@ -47,10 +47,10 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run1['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* fib */');
-    expect(output.run2['main.js'].toString()).to.contain('__webpack_require__.d(exports, "a"');
-    expect(output.run2['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_require__.d(__webpack_exports__, "a"');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-commonjs-module', {
@@ -65,10 +65,10 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run1['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('__webpack_require__(0).fib');
-    expect(output.run2['main.js'].toString()).to.contain('__webpack_require__.d(exports, "fib"');
-    expect(output.run2['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_require__.d(__webpack_exports__, "fib"');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-export-module', {
@@ -83,9 +83,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run1['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* fib */');
-    expect(output.run2['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-export-order-module', {
@@ -148,9 +148,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run1['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* fib */');
-    expect(output.run2['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-default-module', {
@@ -165,9 +165,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run1['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"b" /* fib */');
-    expect(output.run2['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-rename-module', {
@@ -182,9 +182,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* rekey */');
-    expect(output.run1['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* refib */');
-    expect(output.run2['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-module', {
@@ -199,9 +199,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* fib */');
-    expect(output.run1['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run2['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-export-module', {
@@ -216,9 +216,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* fib */');
-    expect(output.run1['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run2['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-all-module', {
@@ -233,9 +233,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* fib */');
-    expect(output.run1['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run2['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-default-module', {
@@ -250,9 +250,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"b" /* fib */');
-    expect(output.run1['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* key */');
-    expect(output.run2['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.contain('__webpack_exports__["a"]');
   });
 
   itCompilesChange('base-change-es2015-rename-module', {
@@ -267,9 +267,9 @@ describeWP2('basic webpack 2 use - builds changes', function() {
     ].join('\n'),
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.contain('"a" /* refib */');
-    expect(output.run1['main.js'].toString()).to.contain('exports["a"]');
+    expect(output.run1['main.js'].toString()).to.contain('__webpack_exports__["a"]');
     expect(output.run2['main.js'].toString()).to.contain('"a" /* rekey */');
-    expect(output.run2['main.js'].toString()).to.not.contain('exports["a"]');
+    expect(output.run2['main.js'].toString()).to.not.contain('__webpack_exports__["a"]');
   });
 
 });

--- a/tests/plugins-webpack-2.js
+++ b/tests/plugins-webpack-2.js
@@ -39,7 +39,7 @@ describeWP2('plugin webpack 2 use - builds changes', function() {
   }, function(output) {
     expect(output.run1['main.js'].toString()).to.match(/return key/);
     expect(output.run1['main.js'].toString()).to.match(/\/* key/);
-    expect(output.run2['main.js'].toString()).to.match(/exports\["a"\]/);
+    expect(output.run2['main.js'].toString()).to.match(/__webpack_exports__\["a"\]/);
     expect(output.run2['main.js'].toString()).to.match(/\/* fib/);
     expect(Object.keys(output.run2).filter(function(key) {
       return /\.hot-update\.json/.test(key);


### PR DESCRIPTION
Fix #88

Webpack 2.2.0 implements some changes that needed fixes in hard source.

- Interop with native classes when extending them (#88)
- Support new HarmonyCompatibilityDependency (currently typoed as HarmonyCompatiblilityDependency in webpack)
- Support exportsArgument when webpack uses `__webpack_exports__` in harmony modules instead of `exports`
- Test against webpack 2 final release