### PR TITLE
Support and test with IgnorePlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -807,6 +807,10 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
                     cacheItem.invalid = true;
                     return reject(err);
                   }
+                  // IgnorePlugin and other plugins can call this callback
+                  // without an error or module.
+                  if (!depModule) {return resolve();}
+
                   if (cacheDependency._resolvedModuleIdentifier === depModule.identifier()) {
                     return resolve();
                   }
@@ -1005,6 +1009,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       return function(request, cb) {
         fn.call(null, request, function(err, result) {
           if (err) {return cb(err);}
+          // IgnorePlugin and other plugins can call this callback without an
+          // error or module.
+          if (!result) {return cb();}
 
           var p = getModuleCacheItem(compilation, result);
           if (p && p.then) {

--- a/lib/hard-context-module-factory.js
+++ b/lib/hard-context-module-factory.js
@@ -67,6 +67,12 @@ HardContextModuleFactory.prototype.create = function(context, dependency, callba
     if (error) {
       return callback(error);
     }
+    // IgnorePlugin and other plugins can call this callback without an error or
+    // module.
+    if (!module) {
+      return callback();
+    }
+
     var identifierPrefix = cachePrefix(compilation);
     if (identifierPrefix === null) {
       return callback(error, module);

--- a/tests/fixtures/plugin-ignore-1dep/fib.js
+++ b/tests/fixtures/plugin-ignore-1dep/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/plugin-ignore-1dep/index.js
+++ b/tests/fixtures/plugin-ignore-1dep/index.js
@@ -1,0 +1,1 @@
+require('./fib');

--- a/tests/fixtures/plugin-ignore-1dep/webpack.config.js
+++ b/tests/fixtures/plugin-ignore-1dep/webpack.config.js
@@ -1,0 +1,22 @@
+var IgnorePlugin = require('webpack').IgnorePlugin;
+
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+    new IgnorePlugin(/\.\/fib/),
+  ],
+};

--- a/tests/fixtures/plugin-ignore-context/a/1.js
+++ b/tests/fixtures/plugin-ignore-context/a/1.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/tests/fixtures/plugin-ignore-context/a/2.js
+++ b/tests/fixtures/plugin-ignore-context/a/2.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/tests/fixtures/plugin-ignore-context/a/3.js
+++ b/tests/fixtures/plugin-ignore-context/a/3.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/tests/fixtures/plugin-ignore-context/a/4.js
+++ b/tests/fixtures/plugin-ignore-context/a/4.js
@@ -1,0 +1,1 @@
+module.exports = 4;

--- a/tests/fixtures/plugin-ignore-context/a/5.js
+++ b/tests/fixtures/plugin-ignore-context/a/5.js
@@ -1,0 +1,1 @@
+module.exports = 5;

--- a/tests/fixtures/plugin-ignore-context/a/index.js
+++ b/tests/fixtures/plugin-ignore-context/a/index.js
@@ -1,0 +1,3 @@
+var context = require.context('.', false, /\d/);
+
+module.exports = 0;

--- a/tests/fixtures/plugin-ignore-context/b/10.js
+++ b/tests/fixtures/plugin-ignore-context/b/10.js
@@ -1,0 +1,1 @@
+module.exports = 10;

--- a/tests/fixtures/plugin-ignore-context/b/6.js
+++ b/tests/fixtures/plugin-ignore-context/b/6.js
@@ -1,0 +1,1 @@
+module.exports = 6;

--- a/tests/fixtures/plugin-ignore-context/b/7.js
+++ b/tests/fixtures/plugin-ignore-context/b/7.js
@@ -1,0 +1,1 @@
+module.exports = 7;

--- a/tests/fixtures/plugin-ignore-context/b/8.js
+++ b/tests/fixtures/plugin-ignore-context/b/8.js
@@ -1,0 +1,1 @@
+module.exports = 8;

--- a/tests/fixtures/plugin-ignore-context/b/9.js
+++ b/tests/fixtures/plugin-ignore-context/b/9.js
@@ -1,0 +1,1 @@
+module.exports = 9;

--- a/tests/fixtures/plugin-ignore-context/b/index.js
+++ b/tests/fixtures/plugin-ignore-context/b/index.js
@@ -1,0 +1,6 @@
+module.exports =
+  require('./6') +
+  require('./7') +
+  require('./8') +
+  require('./9') +
+  require('./10');

--- a/tests/fixtures/plugin-ignore-context/index.js
+++ b/tests/fixtures/plugin-ignore-context/index.js
@@ -1,0 +1,1 @@
+console.log(require('./a') + require('./b'));

--- a/tests/fixtures/plugin-ignore-context/webpack.config.js
+++ b/tests/fixtures/plugin-ignore-context/webpack.config.js
@@ -1,0 +1,21 @@
+var IgnorePlugin = require('webpack').IgnorePlugin;
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+    new IgnorePlugin(/\.\/a\/[1-5]/),
+  ],
+};

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -24,6 +24,8 @@ describe('plugin webpack use', function() {
   itCompilesTwice('plugin-hmr-accept', {exportStats: true});
   itCompilesTwice('plugin-hmr-accept-dep', {exportStats: true});
   itCompilesTwice('plugin-hmr-process-env', {exportStats: true});
+  itCompilesTwice('plugin-ignore-1dep');
+  itCompilesTwice('plugin-ignore-context');
 
   itCompilesHardModules('plugin-dll', ['./fib.js']);
   itCompilesHardModules('plugin-dll-reference', ['./index.js']);


### PR DESCRIPTION
- Test IgnorePlugin on NormalModules
- Test IgnorePlugin on members of a ContextModule
- Test IgnorePlugin on a ContextModule

Implement the tiny logic needed to handle resolver and factory
callbacks that don't return modules due to plugins like IgnorePlugin.