### PR TITLE
Rename HarmonyCompatiblilityDependency to Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ node_js:
 env:
   matrix:
     - WEBPACK_VERSION=1.13.1
-    - WEBPACK_VERSION=2.2.0 EXTRACT_TEXT_VERSION=2.0.0-beta.5
+    - WEBPACK_VERSION=2.2.1 EXTRACT_TEXT_VERSION=2.0.0-rc.3
 matrix:
   fast_finish: true
   allow_failures:
     - node_js: "4"
-      env: WEBPACK_VERSION=2.2.0 EXTRACT_TEXT_VERSION=2.0.0-beta.5
+      env: WEBPACK_VERSION=2.2.1 EXTRACT_TEXT_VERSION=2.0.0-rc.3
 before_script:
   - npm rm webpack extract-text-webpack-plugin
   - npm install webpack@$WEBPACK_VERSION extract-text-webpack-plugin@$EXTRACT_TEXT_VERSION

--- a/index.js
+++ b/index.js
@@ -38,21 +38,27 @@ try{
 }
 var NullFactory = require('webpack/lib/NullFactory');
 
-var HarmonyCompatiblilityDependency;
+var HarmonyCompatibilityDependency;
 var HarmonyExportImportedSpecifierDependency;
 var HarmonyImportDependency;
 var HarmonyImportSpecifierDependency;
 var ImportContextDependency;
 
 try {
-  HarmonyCompatiblilityDependency = require('webpack/lib/dependencies/HarmonyCompatiblilityDependency');
   HarmonyExportImportedSpecifierDependency = require('webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency');
   HarmonyImportDependency = require('webpack/lib/dependencies/HarmonyImportDependency');
   HarmonyImportSpecifierDependency = require('webpack/lib/dependencies/HarmonyImportSpecifierDependency');
   ImportContextDependency = require('webpack/lib/dependencies/ImportContextDependency');
+
+  try {
+    HarmonyCompatibilityDependency = require('webpack/lib/dependencies/HarmonyCompatibilityDependency');
+  }
+  catch (_) {
+    HarmonyCompatibilityDependency = require('webpack/lib/dependencies/HarmonyCompatiblilityDependency');
+  }
 }
 catch (_) {
-  HarmonyCompatiblilityDependency = function() {};
+  HarmonyCompatibilityDependency = function() {};
 }
 
 var HardModuleDependency = require('./lib/dependencies').HardModuleDependency;
@@ -64,7 +70,7 @@ require('./lib/dependencies').HardHarmonyImportDependency;
 var HardHarmonyImportSpecifierDependency =
 require('./lib/dependencies').HardHarmonyImportSpecifierDependency;
 var HardHarmonyExportImportedSpecifierDependency = require('./lib/dependencies').HardHarmonyExportImportedSpecifierDependency;
-var HardHarmonyCompatiblilityDependency = require('./lib/dependencies').HardHarmonyCompatiblilityDependency;
+var HardHarmonyCompatibilityDependency = require('./lib/dependencies').HardHarmonyCompatibilityDependency;
 
 var FileSerializer = require('./lib/cache-serializers').FileSerializer;
 var LevelDbSerializer = require('./lib/cache-serializers').LevelDbSerializer;
@@ -134,7 +140,7 @@ function serializeDependencies(deps, parent) {
           loc: flattenPrototype(dep.loc),
         };
       }
-      else if (dep instanceof HarmonyCompatiblilityDependency) {
+      else if (dep instanceof HarmonyCompatibilityDependency) {
         cacheDep = {
           harmonyCompatibility: true,
         };
@@ -879,8 +885,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     compilation.dependencyFactories.set(HardHarmonyImportSpecifierDependency, new NullFactory());
     compilation.dependencyTemplates.set(HardHarmonyImportSpecifierDependency, new NullDependencyTemplate);
 
-    compilation.dependencyFactories.set(HardHarmonyCompatiblilityDependency, new NullFactory());
-    compilation.dependencyTemplates.set(HardHarmonyCompatiblilityDependency, new NullDependencyTemplate);
+    compilation.dependencyFactories.set(HardHarmonyCompatibilityDependency, new NullFactory());
+    compilation.dependencyTemplates.set(HardHarmonyCompatibilityDependency, new NullDependencyTemplate);
 
     compilation.dependencyFactories.set(HardHarmonyExportImportedSpecifierDependency, new NullFactory());
     compilation.dependencyTemplates.set(HardHarmonyExportImportedSpecifierDependency, new NullDependencyTemplate);

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -8,12 +8,17 @@ try {
 }
 catch (_) {}
 
-var HarmonyModulesHelpers, HarmonyImportSpecifierDependency, HarmonyExportImportedSpecifierDependency, HarmonyCompatiblilityDependency;
+var HarmonyModulesHelpers, HarmonyImportSpecifierDependency, HarmonyExportImportedSpecifierDependency, HarmonyCompatibilityDependency;
 try {
   HarmonyModulesHelpers = require("webpack/lib/dependencies/HarmonyModulesHelpers");
   HarmonyImportSpecifierDependency = require('webpack/lib/dependencies/HarmonyImportSpecifierDependency');
   HarmonyExportImportedSpecifierDependency = require('webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency');
-  HarmonyCompatiblilityDependency = require('webpack/lib/dependencies/HarmonyCompatiblilityDependency');
+  try {
+    HarmonyCompatibilityDependency = require('webpack/lib/dependencies/HarmonyCompatibilityDependency');
+  }
+  catch (_) {
+    HarmonyCompatibilityDependency = require('webpack/lib/dependencies/HarmonyCompatiblilityDependency');
+  }
 }
 catch (_) {}
 
@@ -25,7 +30,7 @@ module.exports = {
   HardHarmonyImportDependency: HardHarmonyImportDependency,
   HardHarmonyImportSpecifierDependency: HardHarmonyImportSpecifierDependency,
   HardHarmonyExportImportedSpecifierDependency: HardHarmonyExportImportedSpecifierDependency,
-  HardHarmonyCompatiblilityDependency: HardHarmonyCompatiblilityDependency,
+  HardHarmonyCompatibilityDependency: HardHarmonyCompatibilityDependency,
 };
 
 function HardModuleDependency(request) {
@@ -150,16 +155,16 @@ if (typeof HarmonyExportImportedSpecifierDependency !== 'undefined') {
   Object.setPrototypeOf(HardHarmonyExportImportedSpecifierDependency, HarmonyExportImportedSpecifierDependency);
 }
 
-function HardHarmonyCompatiblilityDependency(originModule) {
+function HardHarmonyCompatibilityDependency(originModule) {
   Object.setPrototypeOf(this,
     Object.setPrototypeOf(
-      new HarmonyCompatiblilityDependency(originModule),
-      HardHarmonyCompatiblilityDependency.prototype
+      new HarmonyCompatibilityDependency(originModule),
+      HardHarmonyCompatibilityDependency.prototype
     )
   );
 }
 
-if (typeof HarmonyCompatiblilityDependency !== 'undefined') {
-  Object.setPrototypeOf(HardHarmonyCompatiblilityDependency.prototype, HarmonyCompatiblilityDependency.prototype);
-  Object.setPrototypeOf(HardHarmonyCompatiblilityDependency, HarmonyCompatiblilityDependency);
+if (typeof HarmonyCompatibilityDependency !== 'undefined') {
+  Object.setPrototypeOf(HardHarmonyCompatibilityDependency.prototype, HarmonyCompatibilityDependency.prototype);
+  Object.setPrototypeOf(HardHarmonyCompatibilityDependency, HarmonyCompatibilityDependency);
 }

--- a/lib/deserialize-dependencies.js
+++ b/lib/deserialize-dependencies.js
@@ -10,7 +10,7 @@ require('./dependencies').HardHarmonyImportDependency;
 var HardHarmonyImportSpecifierDependency =
 require('./dependencies').HardHarmonyImportSpecifierDependency;
 var HardHarmonyExportImportedSpecifierDependency = require('./dependencies').HardHarmonyExportImportedSpecifierDependency;
-var HardHarmonyCompatiblilityDependency = require('./dependencies').HardHarmonyCompatiblilityDependency;
+var HardHarmonyCompatibilityDependency = require('./dependencies').HardHarmonyCompatibilityDependency;
 
 exports.dependencies = deserializeDependencies;
 exports.variables = deserializeVariables;
@@ -52,7 +52,7 @@ function deserializeDependencies(deps, parent) {
       return new HardHarmonyExportImportedSpecifierDependency(parent, this.state.imports[req.harmonyRequest], req.harmonyId, req.harmonyName);
     }
     if (req.harmonyCompatibility) {
-      return new HardHarmonyCompatiblilityDependency(parent);
+      return new HardHarmonyCompatibilityDependency(parent);
     }
     var dep = new HardModuleDependency(req.request);
     dep.loc = req.loc;


### PR DESCRIPTION
Fix #95

webpack@2.2.0 added a HarmonyCompatiblityDependency that we needed to
support for the exports -> __webpack_exports__ module iife wrapper. But
the dependency's name was typo'd so we use the typo'd name to be true
to webpack at the time. webpack has since released a fix for the typo
and hard-source needs to update to that name.