### PR TITLE
Test and fix optional dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,7 @@ function serializeDependencies(deps, parent) {
         recursive: dep.recursive,
         regExp: dep.regExp ? dep.regExp.source : null,
         async: dep.async,
+        optional: dep.optional,
         loc: flattenPrototype(dep.loc),
       };
     }

--- a/lib/deserialize-dependencies.js
+++ b/lib/deserialize-dependencies.js
@@ -23,6 +23,9 @@ function deserializeDependencies(deps, parent) {
       dep.critical = req.contextCritical;
       dep.async = req.async;
       dep.loc = req.loc;
+      if (req.optional) {
+        dep.optional = true;
+      }
       return dep;
     }
     if (req.constDependency) {
@@ -56,6 +59,9 @@ function deserializeDependencies(deps, parent) {
     }
     var dep = new HardModuleDependency(req.request);
     dep.loc = req.loc;
+    if (req.optional) {
+      dep.optional = true;
+    }
     return dep;
   }, this);
 }

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -24,6 +24,8 @@ describe('basic webpack use - compiles identically', function() {
   itCompilesTwice('base-amd-context');
   itCompilesTwice('base-amd-code-split');
   itCompilesTwice('base-external');
+  itCompilesTwice('base-1dep-optional', {exportStats: true});
+  itCompilesTwice('base-context-optional', {exportStats: true});
 
 });
 

--- a/tests/fixtures/base-1dep-optional/index.js
+++ b/tests/fixtures/base-1dep-optional/index.js
@@ -1,0 +1,9 @@
+var fib;
+try {
+  fib = require('./fib');
+}
+catch (_) {
+  fib = function(v) {return v;};
+}
+
+console.log(fib(3));

--- a/tests/fixtures/base-1dep-optional/webpack.config.js
+++ b/tests/fixtures/base-1dep-optional/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/base-context-optional/b/10.js
+++ b/tests/fixtures/base-context-optional/b/10.js
@@ -1,0 +1,1 @@
+module.exports = 10;

--- a/tests/fixtures/base-context-optional/b/6.js
+++ b/tests/fixtures/base-context-optional/b/6.js
@@ -1,0 +1,1 @@
+module.exports = 6;

--- a/tests/fixtures/base-context-optional/b/7.js
+++ b/tests/fixtures/base-context-optional/b/7.js
@@ -1,0 +1,1 @@
+module.exports = 7;

--- a/tests/fixtures/base-context-optional/b/8.js
+++ b/tests/fixtures/base-context-optional/b/8.js
@@ -1,0 +1,1 @@
+module.exports = 8;

--- a/tests/fixtures/base-context-optional/b/9.js
+++ b/tests/fixtures/base-context-optional/b/9.js
@@ -1,0 +1,1 @@
+module.exports = 9;

--- a/tests/fixtures/base-context-optional/b/index.js
+++ b/tests/fixtures/base-context-optional/b/index.js
@@ -1,0 +1,6 @@
+module.exports =
+  require('./6') +
+  require('./7') +
+  require('./8') +
+  require('./9') +
+  require('./10');

--- a/tests/fixtures/base-context-optional/index.js
+++ b/tests/fixtures/base-context-optional/index.js
@@ -1,0 +1,8 @@
+var a = 0;
+try {
+  var context = require.context('./a');
+  context.keys().forEach(function(m) {a += context(m);});
+}
+catch (_) {}
+
+console.log(a + require('./b'));

--- a/tests/fixtures/base-context-optional/webpack.config.js
+++ b/tests/fixtures/base-context-optional/webpack.config.js
@@ -1,0 +1,16 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+    }),
+  ],
+};


### PR DESCRIPTION
Fix #98

Dependencies like those in try statements are marked as optional by
webpack and failing to resolve them is only considered warnings.
Serialize the `optional` dependency attribute so this can persist
between builds.