### PR TITLE
Fix travis / dev dependency versions for extract-text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ node_js:
 
 env:
   matrix:
-    - WEBPACK_VERSION=1.13.1
-    - WEBPACK_VERSION=2.2.1 EXTRACT_TEXT_VERSION=2.0.0-rc.3
+    - WEBPACK_VERSION=1.13.1 EXTRACT_TEXT_VERSION=1
+    - WEBPACK_VERSION=2.2.1 EXTRACT_TEXT_VERSION=2.0.0
 matrix:
   fast_finish: true
   allow_failures:
     - node_js: "4"
-      env: WEBPACK_VERSION=2.2.1 EXTRACT_TEXT_VERSION=2.0.0-rc.3
+      env: WEBPACK_VERSION=2.2.1 EXTRACT_TEXT_VERSION=2.0.0
 before_script:
   - npm rm webpack extract-text-webpack-plugin
   - npm install webpack@$WEBPACK_VERSION extract-text-webpack-plugin@$EXTRACT_TEXT_VERSION

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "css-loader": "^0.26.1",
-    "extract-text-webpack-plugin": "^1.0.1 || ^2.0.0-beta",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.22.0",
     "memory-fs": "^0.4.1",

--- a/tests/fixtures/base-1dep-optional/webpack.config.js
+++ b/tests/fixtures/base-1dep-optional/webpack.config.js
@@ -1,4 +1,5 @@
 var HardSourceWebpackPlugin = require('../../..');
+var webpackIf = require('../../util/webpack-if');
 
 module.exports = {
   context: __dirname,
@@ -6,6 +7,13 @@ module.exports = {
   output: {
     path: __dirname + '/tmp',
     filename: 'main.js',
+  },
+  // Restrict extensions in this test to improve reducability. Since this test
+  // tests resolve warnings having more extensions can produce different results
+  // because of the order failing extensions are tried.
+  resolve: {
+    // Versions after webpack 1 do not allow empty string values.
+    extensions: webpackIf.webpack1(['', '.js'], ['.js']),
   },
   recordsPath: __dirname + '/tmp/cache/records.json',
   plugins: [

--- a/tests/util/webpack-if.js
+++ b/tests/util/webpack-if.js
@@ -1,0 +1,27 @@
+exports.webpack1 = function(obj, elseObj) {
+  if (require('webpack/package.json').version[0] === '1') {
+    return obj;
+  }
+  else {
+    return elseObj;
+  }
+};
+
+exports.webpack2 = function(obj, elseObj) {
+  if (require('webpack/package.json').version[0] === '2') {
+    return obj;
+  }
+  else {
+    return elseObj;
+  }
+};
+
+exports.removeEmptyValues = function(obj) {
+  var _obj = {};
+  for (var key in obj) {
+    if (obj[key]) {
+      _obj[key] = obj[key];
+    }
+  }
+  return _obj;
+};


### PR DESCRIPTION
`extract-text@2` finally landed. That caused recent tests to fail for test jobs testing with webpack 1. Setup travis and dev dependencies to default to extract 1.