### PR TITLE
Fix child compiler resolutions that collide in the resolve cache

### DIFF
--- a/tests/fixtures/plugin-child-compiler-resolutions/child-compilation-plugin.js
+++ b/tests/fixtures/plugin-child-compiler-resolutions/child-compilation-plugin.js
@@ -1,0 +1,44 @@
+var SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
+
+var RuleSet;
+try {
+  RuleSet = require('webpack/lib/RuleSet');
+}
+catch(error) {}
+
+module.exports = ChildCompilationPlugin;
+
+function ChildCompilationPlugin(loaders) {
+  this.loaders = loaders;
+};
+
+ChildCompilationPlugin.prototype.apply = function(compiler) {
+  var loaders = this.loaders;
+  compiler.plugin('make', function(compilation, cb) {
+    var compilerName = 'child';
+    var child = compilation.createChildCompiler(compilerName, {});
+    child.apply(new SingleEntryPlugin(compiler.options.context, compiler.options.entry, 'child'));
+    child.plugin('compilation', function(compilation, params) {
+      if (RuleSet) {
+        params.normalModuleFactory.rules = new RuleSet(loaders);
+      }
+      else {
+        params.normalModuleFactory.loaders.list = loaders;
+      }
+    });
+    // Create a nested compilation cache. Webpack plugins making child compilers
+    // must do this to not collide with modules used by other child compilations
+    // (or the top level one). As well hard-source uses this to build a
+    // compilation identifier so it can cache modules and other data per
+    // compilation.
+    child.plugin('compilation', function (compilation) {
+      if (compilation.cache) {
+        if (!compilation.cache[compilerName]) {
+          compilation.cache[compilerName] = {};
+        }
+        compilation.cache = compilation.cache[compilerName];
+      }
+    });
+    child.runAsChild(cb);
+  });
+};

--- a/tests/fixtures/plugin-child-compiler-resolutions/fib.js
+++ b/tests/fixtures/plugin-child-compiler-resolutions/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/plugin-child-compiler-resolutions/index.js
+++ b/tests/fixtures/plugin-child-compiler-resolutions/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/plugin-child-compiler-resolutions/loader-a.js
+++ b/tests/fixtures/plugin-child-compiler-resolutions/loader-a.js
@@ -1,0 +1,4 @@
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  return '// loader-a\n' + source;
+};

--- a/tests/fixtures/plugin-child-compiler-resolutions/loader-b.js
+++ b/tests/fixtures/plugin-child-compiler-resolutions/loader-b.js
@@ -1,0 +1,4 @@
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  return '// loader-b\n' + source;
+};

--- a/tests/fixtures/plugin-child-compiler-resolutions/webpack.config.js
+++ b/tests/fixtures/plugin-child-compiler-resolutions/webpack.config.js
@@ -1,0 +1,50 @@
+var join = require('path').join;
+
+var HardSourceWebpackPlugin = require('../../..');
+
+var ChildCompilationPlugin = require('./child-compilation-plugin');
+var webpackIf = require('../../util/webpack-if');
+
+var loaders = [
+  {
+    test: /\.js$/,
+    loader: 'loader-a',
+  },
+];
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: '[name].js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+
+  module: webpackIf.removeEmptyValues({
+    loaders: webpackIf.webpack1(loaders),
+    rules: webpackIf.webpack2(loaders),
+  }),
+
+  resolveLoader: {
+    alias: {
+      'loader-a': join(__dirname, 'loader-a.js'),
+      'loader-b': join(__dirname, 'loader-b.js'),
+    },
+  },
+
+  plugins: [
+    new ChildCompilationPlugin([
+      {
+        test: /\.js$/,
+        loader: 'loader-b',
+      },
+    ]),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/plugins-webpack-1.js
+++ b/tests/plugins-webpack-1.js
@@ -27,6 +27,7 @@ describe('plugin webpack use', function() {
   itCompilesTwice('plugin-ignore-1dep');
   itCompilesTwice('plugin-ignore-context');
   itCompilesTwice('plugin-ignore-context-members');
+  itCompilesTwice('plugin-child-compiler-resolutions');
 
   itCompilesHardModules('plugin-dll', ['./fib.js']);
   itCompilesHardModules('plugin-dll-reference', ['./index.js']);

--- a/tests/plugins-webpack-2.js
+++ b/tests/plugins-webpack-2.js
@@ -18,11 +18,16 @@ describeWP2('plugin webpack 2 use - builds changes', function() {
   }, function(output) {
     var main1 = output.run1['main.js'].toString();
     var main2 = output.run2['main.js'].toString();
-    var id1 = /var (\w)=\w\(0\)/.exec(main1)[1];
-    var id2 = /var (\w)=\w\(0\)/.exec(main2)[1];
-    expect(main1).to.contain(id1 + '.a');
+    var run1Ids = /var (\w)=(\w)\(0\)/.exec(main1);
+    var run2Ids = /var (\w)=(\w)\(0\)/.exec(main2);
+    var run1Module = run1Ids[1];
+    var run1Require = run1Ids[2];
+    var run2Module = run2Ids[1];
+    var run2Require = run2Ids[2];
+    expect(main1).to.contain(run1Module + '.a');
+    expect(main1).to.not.contain(run1Require + '.i(' + run1Module + '.a)');
     expect(main1).to.not.match(/(\w\.a)=function/);
-    expect(main2).to.contain('r.i(' + id2 + '.a)');
+    expect(main2).to.contain(run2Require + '.i(' + run2Module + '.a)');
     expect(main2).to.match(/(\w\.a)=function/);
   });
 


### PR DESCRIPTION
Track NormalModule resolutions per compilation like modules so that
multiple compilations that have different rules (auto-loader
configuration) correctly resolve different modules.