### PR TITLE
Serialize error details and rehydrate it

### DIFF
--- a/index.js
+++ b/index.js
@@ -1298,6 +1298,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     function serializeError(error, parent) {
       var serialized = {
         message: error.message,
+        details: error.details,
       };
       if (error.origin) {
         serialized.origin = serializeDependencies([error.origin], parent, compilation)[0];

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -118,6 +118,10 @@ HardModule.prototype.libIdent = function(options) {
 function deserializeError(ErrorClass, state) {
   return function(serialized) {
     var err = new ErrorClass(this, serialized.message);
+    if (serialized.details) {
+      err.details = serialized.details;
+    }
+
     if (serialized.origin) {
       err.origin = deserializeDependencies.dependencies.call(state, [serialized.origin], this)[0];
     }


### PR DESCRIPTION
webpack 2 later errors include details. Serializing them the errors
will continue to look the same as previous builds.