### PR TITLE
Give all options default behaviours

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module.exports = {
         // replaced if [confighash] does not appear in cacheDirectory.
         //
         // node-object-hash on npm can be used to build this.
-        return require('node-object-hash')().hash(webpackConfig);
+        return require('node-object-hash')({sort: false}).hash(webpackConfig);
       },
       // Optional field. This field determines when to throw away the whole
       // cache if for example npm modules were updated.

--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
     "level": "^1.4.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
+    "node-object-hash": "^1.2.0",
     "source-list-map": "^0.1.6",
     "source-map": "^0.5.6",
-    "webpack-sources": "^0.1.2",
-    "webpack-core": "~0.6.0"
+    "webpack-core": "~0.6.0",
+    "webpack-sources": "^0.1.2"
   }
 }

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -37,6 +37,7 @@ describe('basic webpack use - compiles hard modules', function() {
   itCompilesHardModules('base-code-split', ['./fib.js', './index.js']);
   itCompilesHardModules('base-query-request', ['./fib.js?argument']);
   itCompilesHardModules('base-external', ['./index.js']);
+  itCompilesHardModules('base-options-default', ['./fib.js', './index.js']);
 
 });
 

--- a/tests/fixtures/base-1dep-optional/webpack.config.js
+++ b/tests/fixtures/base-1dep-optional/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-1dep/webpack.config.js
+++ b/tests/fixtures/base-1dep/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-amd-1dep/webpack.config.js
+++ b/tests/fixtures/base-amd-1dep/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-amd-context/webpack.config.js
+++ b/tests/fixtures/base-amd-context/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-change-1dep/webpack.config.js
+++ b/tests/fixtures/base-change-1dep/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-change-es2015-all-module/webpack.config.js
+++ b/tests/fixtures/base-change-es2015-all-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-change-es2015-commonjs-module/webpack.config.js
+++ b/tests/fixtures/base-change-es2015-commonjs-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-change-es2015-default-module/webpack.config.js
+++ b/tests/fixtures/base-change-es2015-default-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-change-es2015-export-module/webpack.config.js
+++ b/tests/fixtures/base-change-es2015-export-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-change-es2015-export-order-module/webpack.config.js
+++ b/tests/fixtures/base-change-es2015-export-order-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-change-es2015-module/webpack.config.js
+++ b/tests/fixtures/base-change-es2015-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-change-es2015-rename-module/webpack.config.js
+++ b/tests/fixtures/base-change-es2015-rename-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-context-move/webpack.config.js
+++ b/tests/fixtures/base-context-move/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-deep-context/webpack.config.js
+++ b/tests/fixtures/base-deep-context/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-error-resolve/webpack.config.js
+++ b/tests/fixtures/base-error-resolve/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-es2015-module-compatibility/webpack.config.js
+++ b/tests/fixtures/base-es2015-module-compatibility/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-es2015-module-export-before-import/webpack.config.js
+++ b/tests/fixtures/base-es2015-module-export-before-import/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-es2015-module-use-before-import/webpack.config.js
+++ b/tests/fixtures/base-es2015-module-use-before-import/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-es2015-module/webpack.config.js
+++ b/tests/fixtures/base-es2015-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-es2015-rename-module/webpack.config.js
+++ b/tests/fixtures/base-es2015-rename-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-es2015-system-context/webpack.config.js
+++ b/tests/fixtures/base-es2015-system-context/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-es2015-system-module/webpack.config.js
+++ b/tests/fixtures/base-es2015-system-module/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-external/webpack.config.js
+++ b/tests/fixtures/base-external/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-move-10deps-1nest/webpack.config.js
+++ b/tests/fixtures/base-move-10deps-1nest/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-move-1dep/webpack.config.js
+++ b/tests/fixtures/base-move-1dep/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-options-default/fib.js
+++ b/tests/fixtures/base-options-default/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-options-default/index.js
+++ b/tests/fixtures/base-options-default/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/base-options-default/webpack.config.js
+++ b/tests/fixtures/base-options-default/webpack.config.js
@@ -1,0 +1,17 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  plugins: [
+    new HardSourceWebpackPlugin({
+      environmentHash: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/base-query-request/webpack.config.js
+++ b/tests/fixtures/base-query-request/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-warning-context/webpack.config.js
+++ b/tests/fixtures/base-warning-context/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/base-warning-es2015/webpack.config.js
+++ b/tests/fixtures/base-warning-es2015/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/hard-source-confighash-dir/webpack.config.js
+++ b/tests/fixtures/hard-source-confighash-dir/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
       configHash: function(config) {
         return fs.readFileSync(__dirname + '/config-hash', 'utf8');
       },
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/hard-source-confighash/webpack.config.js
+++ b/tests/fixtures/hard-source-confighash/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
       configHash: function(config) {
         return fs.readFileSync(__dirname + '/config-hash', 'utf8');
       },
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/hard-source-md5/webpack.config.js
+++ b/tests/fixtures/hard-source-md5/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
       configHash: function(config) {
         return fs.readFileSync(__dirname + '/config-hash', 'utf8');
       },
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/loader-custom-context-dep/webpack.config.js
+++ b/tests/fixtures/loader-custom-context-dep/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/loader-custom-deep-context-dep/webpack.config.js
+++ b/tests/fixtures/loader-custom-deep-context-dep/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/loader-custom-missing-dep-added/webpack.config.js
+++ b/tests/fixtures/loader-custom-missing-dep-added/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/loader-custom-missing-dep/webpack.config.js
+++ b/tests/fixtures/loader-custom-missing-dep/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/loader-custom-no-dep-moved/webpack.config.js
+++ b/tests/fixtures/loader-custom-no-dep-moved/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/loader-custom-no-dep/webpack.config.js
+++ b/tests/fixtures/loader-custom-no-dep/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/loader-custom-prepend-helper/webpack.config.js
+++ b/tests/fixtures/loader-custom-prepend-helper/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/loader-custom-user-loader/webpack.config.js
+++ b/tests/fixtures/loader-custom-user-loader/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-child-compiler-resolutions/webpack.config.js
+++ b/tests/fixtures/plugin-child-compiler-resolutions/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
     ]),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-dll-reference-scope/webpack.config.js
+++ b/tests/fixtures/plugin-dll-reference-scope/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-dll-reference/webpack.config.js
+++ b/tests/fixtures/plugin-dll-reference/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-dll/webpack.config.js
+++ b/tests/fixtures/plugin-dll/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-extract-text-html-uglify/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text-html-uglify/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
     new UglifyJsPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-extract-text-loader-file/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text-loader-file/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
     new ExtractTextPlugin('style.css'),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-extract-text-uglify-eval-source-map/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text-uglify-eval-source-map/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
     new UglifyJsPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-extract-text-uglify-source-map/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text-uglify-source-map/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
     new UglifyJsPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-extract-text-uglify/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text-uglify/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
     new UglifyJsPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-extract-text/webpack.config.js
+++ b/tests/fixtures/plugin-extract-text/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = {
     new ExtractTextPlugin('style.css'),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-hmr-accept-dep/webpack.config.js
+++ b/tests/fixtures/plugin-hmr-accept-dep/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     new HotModuleReplacementPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: __dirname + '/tmp/cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-hmr-accept/webpack.config.js
+++ b/tests/fixtures/plugin-hmr-accept/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     new HotModuleReplacementPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: __dirname + '/tmp/cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-hmr-es2015/webpack.config.js
+++ b/tests/fixtures/plugin-hmr-es2015/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     new HotModuleReplacementPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: __dirname + '/tmp/cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-hmr-process-env/webpack.config.js
+++ b/tests/fixtures/plugin-hmr-process-env/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     new HotModuleReplacementPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: __dirname + '/tmp/cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-hmr/webpack.config.js
+++ b/tests/fixtures/plugin-hmr/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     new HotModuleReplacementPlugin(),
     new HardSourceWebpackPlugin({
       cacheDirectory: __dirname + '/tmp/cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-html-lodash/webpack.config.js
+++ b/tests/fixtures/plugin-html-lodash/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
     }),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-ignore-1dep/webpack.config.js
+++ b/tests/fixtures/plugin-ignore-1dep/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-ignore-context-members/webpack.config.js
+++ b/tests/fixtures/plugin-ignore-context-members/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-ignore-context/webpack.config.js
+++ b/tests/fixtures/plugin-ignore-context/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-isomorphic-tools/webpack.config.js
+++ b/tests/fixtures/plugin-isomorphic-tools/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
     webpackIsomorphicToolsPlugin.development(),
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-uglify-1dep-es2015/webpack.config.js
+++ b/tests/fixtures/plugin-uglify-1dep-es2015/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/fixtures/plugin-uglify-1dep/webpack.config.js
+++ b/tests/fixtures/plugin-uglify-1dep/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   plugins: [
     new HardSourceWebpackPlugin({
       cacheDirectory: 'cache',
-      environmentPaths: {
+      environmentHash: {
         root: __dirname + '/../../..',
       },
     }),

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -44,6 +44,7 @@ exports.compile = function(fixturePath, options) {
   .then(function(stats) {
     return Promise.all([
       readdir(compiler.options.output.path)
+      .catch(function() {return [];})
       .map(function(name) {
         var fullname = path.join(compiler.options.output.path, name);
         return stat(fullname)
@@ -55,6 +56,7 @@ exports.compile = function(fixturePath, options) {
         });
       }),
       fsReaddir(compiler.options.output.path)
+      .catch(function() {return [];})
       .map(function(name) {
         var fullname = path.join(compiler.options.output.path, name);
         return fsStat(fullname)
@@ -154,6 +156,7 @@ exports.readFiles = function(outputPath) {
   var fsStat = Promise.promisify(fs.stat, {context: fs});
 
   return fsReaddir(outputPath)
+  .catch(function() {return [];})
   .map(function(name) {
     var fullname = path.join(outputPath, name);
     return fsStat(fullname)


### PR DESCRIPTION
- Fix #124: Set default node-object-hash hasher to sort: false
- Store the cache in node_modules/.cache/hard-source/[confighash] by default
- Test the default options and make sure hard-modules are created