### PR TITLE
Add and use a LoggerFactory to pluginify hard-source logging

### DIFF
--- a/lib/logger-factory.js
+++ b/lib/logger-factory.js
@@ -1,0 +1,206 @@
+/**
+ * The LoggerFactory wraps a hard source plugin exposed on the webpack Compiler.
+ *
+ * The plugin handle, `'hard-source-log'` takes one object as input and should
+ * log it to the console, disk, or somewhere. Or not if it the message should
+ * be ignored. The object has a few arguments that generally follows this
+ * structure. The `data` key will generally have an `id` value.
+ *
+ * ```js
+ * {
+ *   from: 'core',
+ *   level: 'error',
+ *   message: 'HardSourceWebpackPlugin requires a cacheDirectory setting.',
+ *   data: {
+ *     id: 'need-cache-directory-option'
+ *   }
+ * }
+ * ```
+ *
+ * So a simple plugin handle may be
+ *
+ * ```js
+ * compiler.plugin('hard-source-log', function(message) {
+ *   console[message.level].call(
+ *     console,
+ *     'hard-source:' + message.from, message.message
+ *   );
+ * });
+ * ```
+ *
+ * @module hard-source-webpack-plugin/logger-factory
+ * @author Michael "Z" Goddard <mzgoddard@gmail.com>
+ */
+
+var LOGGER_SEPARATOR = ':';
+var DEFAULT_LOGGER_PREFIX = 'hard-source';
+var LOGGER_FACTORY_COMPILER_KEY = __dirname +
+  '/hard-source-logger-factory-compiler-key';
+
+/**
+ * @constructor Logger
+ * @memberof module:hard-source-webpack-plugin/logger-factory
+ */
+function Logger(compiler) {
+  this.compiler = compiler;
+  this._lock = null;
+}
+
+/**
+ * @method lock
+ * @memberof module:hard-source-webpack-plugin/logger-factory~Logger#
+ */
+Logger.prototype.lock = function() {
+  this._lock = [];
+};
+
+/**
+ * @method unlock
+ * @memberof module:hard-source-webpack-plugin/logger-factory~Logger#
+ */
+Logger.prototype.unlock = function() {
+  var _this = this;
+  if (_this._lock) {
+    var lock = _this._lock;
+    _this._lock = null;
+    lock.forEach(function(value) {_this.write(value);});
+  }
+};
+
+/**
+ * @method write
+ * @memberof module:hard-source-webpack-plugin/logger-factory~Logger#
+ */
+Logger.prototype.write = function(value) {
+  if (this._lock) {
+    return this._lock.push(value);
+  }
+
+  if (
+    this.compiler._plugins['hard-source-log'] &&
+    this.compiler._plugins['hard-source-log'].length
+  ) {
+    (
+      this.compiler.applyPlugins1 ||
+      this.compiler.applyPlugins
+    ).call(this.compiler, 'hard-source-log', value);
+  }
+  else {
+    console[value.level].call(
+      console,
+      '[' + DEFAULT_LOGGER_PREFIX + LOGGER_SEPARATOR + value.from + ']',
+      value.message
+    );
+  }
+};
+
+/**
+ * @method from
+ * @memberof module:hard-source-webpack-plugin/logger-factory~Logger#
+ */
+Logger.prototype.from = function(name) {
+  return new LoggerFrom(this, name);
+};
+
+/**
+ * @constructor LoggerFrom
+ * @memberof module:hard-source-webpack-plugin/logger-factory
+ */
+function LoggerFrom(logger, from) {
+  this._logger = logger;
+  this._from = from;
+}
+
+/**
+ * @method from
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFrom#
+ */
+LoggerFrom.prototype.from = function(name) {
+  return new LoggerFrom(this._logger, this._from + LOGGER_SEPARATOR + name);
+};
+
+/**
+ * @method _write
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFrom#
+ */
+LoggerFrom.prototype._write = function(level, data, message) {
+  this._logger.write({
+    from: this._from,
+    level: level,
+    message: message,
+    data: data,
+  });
+};
+
+/**
+ * @method error
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFrom#
+ */
+LoggerFrom.prototype.error = function(data, message) {
+  this._write('error', data, message);
+};
+
+/**
+ * @method warn
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFrom#
+ */
+LoggerFrom.prototype.warn = function(data, message) {
+  this._write('warn', data, message);
+};
+
+/**
+ * @method info
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFrom#
+ */
+LoggerFrom.prototype.info = function(data, message) {
+  this._write('info', data, message);
+};
+
+/**
+ * @method log
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFrom#
+ */
+LoggerFrom.prototype.log = function(data, message) {
+  this._write('log', data, message);
+};
+
+/**
+ * @method debug
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFrom#
+ */
+LoggerFrom.prototype.debug = function(data, message) {
+  this._write('debug', data, message);
+};
+
+/**
+ * @constructor LoggerFactory
+ * @memberof module:hard-source-webpack-plugin/logger-factory
+ */
+function LoggerFactory(compiler) {
+  this.compiler = compiler;
+}
+
+/**
+ * @method create
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFactory#
+ */
+LoggerFactory.prototype.create = function() {
+  var compiler = this.compiler;
+  if (!compiler[LOGGER_FACTORY_COMPILER_KEY]) {
+    compiler[LOGGER_FACTORY_COMPILER_KEY] = new Logger(this.compiler);
+  }
+  return compiler[LOGGER_FACTORY_COMPILER_KEY];
+};
+
+/**
+ * @function getLogger
+ * @memberof module:hard-source-webpack-plugin/logger-factory~LoggerFactory.
+ */
+LoggerFactory.getLogger = function(compilation) {
+  while (compilation.compiler.parentCompilation) {
+    compilation = compilation.compiler.parentCompilation;
+  }
+  return new LoggerFactory(compilation.compiler).create();
+};
+
+module.exports = LoggerFactory;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,8 @@
 var fs = require('fs');
 var path = require('path');
 
+var LoggerFactory = require('./logger-factory');
+
 exports.cachePrefix = cachePrefix;
 
 var NS = fs.realpathSync(path.dirname(__dirname));
@@ -18,12 +20,19 @@ function cachePrefix(compilation) {
       if (!nextCompilation.cache) {
         if (cachePrefixErrorOnce) {
           cachePrefixErrorOnce = false;
-          console.error([
-            'A child compiler (' + compilation.compiler.name + ') does not',
-            'have a memory cache. Enable a memory cache with webpack\'s',
-            '`cache` configuration option. HardSourceWebpackPlugin will be',
-            'disabled for this child compiler until then.',
-          ].join('\n'));
+          var loggerUtil = LoggerFactory.getLogger(compilation).from('util');
+          loggerUtil.error(
+            {
+              id: 'child-compiler-no-memory-cache',
+              compilerName: compilation.compiler.name
+            },
+            [
+              'A child compiler (' + compilation.compiler.name + ') does not',
+              'have a memory cache. Enable a memory cache with webpack\'s',
+              '`cache` configuration option. HardSourceWebpackPlugin will be',
+              'disabled for this child compiler until then.',
+            ].join('\n')
+          );
         }
         prefix = null;
         break;
@@ -48,12 +57,19 @@ function cachePrefix(compilation) {
       if (!cacheKey) {
         if (cachePrefixErrorOnce) {
           cachePrefixErrorOnce = false;
-          console.error([
-            'A child compiler (' + compilation.compiler.name + ') has a',
-            'memory cache but its cache name is unknown.',
-            'HardSourceWebpackPlugin will be disabled for this child',
-            'compiler.',
-          ].join('\n'));
+          var loggerUtil = LoggerFactory.getLogger(compilation).from('util');
+          loggerUtil.error(
+            {
+              id: 'child-compiler-unnamed-memory-cache',
+              compilerName: compilation.compiler.name
+            },
+            [
+              'A child compiler (' + compilation.compiler.name + ') has a',
+              'memory cache but its cache name is unknown.',
+              'HardSourceWebpackPlugin will be disabled for this child',
+              'compiler.',
+            ].join('\n')
+          );
         }
         prefix = null;
         break;

--- a/tests/fixtures/plugin-logger-child-no-memory/fib.js
+++ b/tests/fixtures/plugin-logger-child-no-memory/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/plugin-logger-child-no-memory/index.js
+++ b/tests/fixtures/plugin-logger-child-no-memory/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/plugin-logger-child-no-memory/webpack.config.js
+++ b/tests/fixtures/plugin-logger-child-no-memory/webpack.config.js
@@ -1,0 +1,42 @@
+var RawSource;
+try {
+  RawSource = require('webpack-sources/lib/RawSource');
+}
+catch (_) {
+  RawSource = require('webpack-core/lib/RawSource');
+}
+
+var SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
+
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: '[name].js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: __dirname + '/tmp/cache',
+      recordsPath: __dirname + '/tmp/cache/records.json',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+    {
+      apply: function(compiler) {
+        var lines = [];
+        compiler.plugin('hard-source-log', function(info) {
+          lines.push([info.level, info.from, info.message]);
+        });
+        compiler.plugin('emit', function(compilation, cb) {
+          compilation.assets['log.json'] = new RawSource(JSON.stringify(lines));
+          cb();
+        });
+      },
+    },
+  ],
+};

--- a/tests/plugins-webpack-1.js
+++ b/tests/plugins-webpack-1.js
@@ -2,6 +2,7 @@ var expect = require('chai').expect;
 
 var clean = require('./util').clean;
 var compile = require('./util').compile;
+var itCompiles = require('./util').itCompiles;
 var itCompilesTwice = require('./util').itCompilesTwice;
 var itCompilesChange = require('./util').itCompilesChange;
 var itCompilesHardModules = require('./util').itCompilesHardModules;
@@ -28,6 +29,7 @@ describe('plugin webpack use', function() {
   itCompilesTwice('plugin-ignore-context');
   itCompilesTwice('plugin-ignore-context-members');
   itCompilesTwice('plugin-child-compiler-resolutions');
+  itCompilesTwice('plugin-logger-child-no-memory');
 
   itCompilesHardModules('plugin-dll', ['./fib.js']);
   itCompilesHardModules('plugin-dll-reference', ['./index.js']);
@@ -103,4 +105,15 @@ describe('plugin webpack use - builds changes', function() {
   //   });
   // });
 
+});
+
+describe('plugin webpack use - logging', function() {
+  itCompiles(
+    'plugin-logger-child-no-memory',
+    'plugin-logger-child-no-memory',
+    function(out) {
+      expect(out.run1['log.json'].toString()).to.not.match(/^[]$/);
+      expect(out.run2['log.json'].toString()).to.not.match(/^[]$/);
+    }
+  );
 });

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -10,6 +10,7 @@ var mkdirp = require('mkdirp');
 var Promise = require('bluebird');
 var rimraf = require('rimraf');
 var webpack = require('webpack');
+var mkdirp = require('mkdirp');
 
 function wrapModule(code) {
   return '(function(exports, require, module, __filename, __dirname) {' +
@@ -343,7 +344,10 @@ exports.itCompilesHardModules = function(fixturePath, filesA, filesB, expectHand
 
 exports.clean = function(fixturePath) {
   var tmpPath = path.join(__dirname, '..', 'fixtures', fixturePath, 'tmp');
-  return Promise.promisify(rimraf)(tmpPath);
+  return Promise.promisify(rimraf)(tmpPath)
+  .then(function() {
+    return Promise.promisify(mkdirp)(tmpPath);
+  });
 };
 
 exports.describeWP2 = function() {


### PR DESCRIPTION
A simple logger plugin would be

```js
class HSLoggerPlugin {
  apply(compiler) {
    compiler.plugin('hard-source-log', message => {
      console[message.level].call(console, message.message);
    });
  }
}
```