### PR TITLE
Add and use a CacheSerializerFactory to pluginify hard-source disk ops

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,8 @@ var cachePrefix = require('./lib/util').cachePrefix;
 var deserializeDependencies = require('./lib/deserialize-dependencies');
 
 var CacheSerializerFactory = require('./lib/cache-serializer-factory');
+var HardSourceJsonSerializerPlugin =
+  require('./lib/hard-source-json-serializer-plugin');
 
 var hardSourceVersion = require('./package.json').version;
 
@@ -268,7 +270,6 @@ HardSourceWebpackPlugin.prototype.getCachePath = function(suffix) {
   return this.getPath(this.options.cacheDirectory, suffix);
 };
 
-module.exports = HardSourceWebpackPlugin;
 HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var options = this.options;
   var active = true;
@@ -1621,3 +1622,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     );
   });
 };
+
+module.exports = HardSourceWebpackPlugin;
+
+HardSourceWebpackPlugin.HardSourceJsonSerializerPlugin = HardSourceJsonSerializerPlugin;

--- a/index.js
+++ b/index.js
@@ -184,10 +184,10 @@ function serializeDependencies(deps, parent, compilation) {
       var _inContextDependencyIdentifier = parent && JSON.stringify([parent.context, cacheDep]);
       // An identifier from the dependency to the cached resolution information
       // for building a module.
-      var _resolveCacheId = parent && cacheDep.request && JSON.stringify([identifierPrefix, parent.context, cacheDep.request]);
+      var _moduleResolveCacheId = parent && cacheDep.request && JSON.stringify([identifierPrefix, parent.context, cacheDep.request]);
       cacheDep._resolvedModuleIdentifier = _resolvedModuleIdentifier;
       cacheDep._inContextDependencyIdentifier = _inContextDependencyIdentifier;
-      cacheDep._resolveCacheId = _resolveCacheId;
+      cacheDep._moduleResolveCacheId = _moduleResolveCacheId;
     }
 
     return cacheDep;
@@ -429,12 +429,14 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var cacheAssetDirPath = path.join(cacheDirPath, 'assets');
   var resolveCachePath = path.join(cacheDirPath, 'resolve.json');
 
-  var resolveCache = {};
   var moduleCache = {};
   var assetCache = {};
   var dataCache = {};
+  var moduleResolveCache = {};
   var md5Cache = {};
   var currentStamp = '';
+
+  var moduleResolveCacheChange = [];
 
   var fileMd5s = {};
   var cachedMd5s = {};
@@ -448,6 +450,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var moduleCacheSerializer;
   var dataCacheSerializer;
   var md5CacheSerializer;
+  var moduleResolveCacheSerializer;
 
   var _this = this;
 
@@ -611,6 +614,11 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           type: 'data',
           cacheDirPath: cacheDirPath,
         });
+        moduleResolveCacheSerializer = cacheSerializerFactory.create({
+          name: 'module-resolve',
+          type: 'data',
+          cacheDirPath: cacheDirPath,
+        });
       }
       catch (err) {
         return cb(err);
@@ -659,10 +667,10 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         }
 
         // Reset the cache, we can't use it do to an environment change.
-        resolveCache = {};
         moduleCache = {};
         assetCache = {};
         dataCache = {};
+        moduleResolveCache = {};
         md5Cache = {};
         fileTimestamps = {};
         contextTimestamps = {};
@@ -672,10 +680,6 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       if (Object.keys(moduleCache).length) {return Promise.resolve();}
 
       return Promise.all([
-        fsReadFile(resolveCachePath, 'utf8')
-        .then(JSON.parse)
-        .then(function(_resolveCache) {resolveCache = _resolveCache}),
-
         assetCacheSerializer.read()
         .then(function(_assetCache) {assetCache = _assetCache;}),
 
@@ -702,6 +706,18 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
             }
 
             cachedMd5s[key] = md5Cache[key].hash;
+          });
+        }),
+
+        moduleResolveCacheSerializer.read()
+        .then(function(_moduleResolveCache) {
+          moduleResolveCache = _moduleResolveCache;
+        })
+        .then(function() {
+          Object.keys(moduleResolveCache).forEach(function(key) {
+            if (typeof moduleResolveCache[key] === 'string') {
+              moduleResolveCache[key] = JSON.parse(moduleResolveCache[key]);
+            }
           });
         }),
       ])
@@ -777,7 +793,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       var hardContextFactory = new HardContextModuleFactory({
         compilation: compilation,
         factory: contextFactory,
-        resolveCache: resolveCache,
+        resolveCache: moduleResolveCache,
         moduleCache: moduleCache,
         fileTimestamps: fileTimestamps,
         fileMd5s: fileMd5s,
@@ -868,8 +884,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
             !cacheDependency.contextDependency &&
             typeof cacheDependency.request !== 'undefined'
           ) {
-            var resolveId = cacheDependency._resolveCacheId;
-            var resolveItem = resolveCache[resolveId];
+            var resolveId = cacheDependency._moduleResolveCacheId;
+            var resolveItem = moduleResolveCache[resolveId];
             if (
               resolveItem &&
               // !resolveItem.invalid
@@ -1104,7 +1120,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
               return cb(err);
             }
             if (!request.source) {
-              resolveCache[cacheId] = Object.assign({}, request, {
+              moduleResolveCacheChange.push(cacheId);
+              moduleResolveCache[cacheId] = Object.assign({}, request, {
                 parser: null,
                 parserOptions: request.parser[NS + '/parser-options'],
                 dependencies: null,
@@ -1115,7 +1132,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         };
 
         var fromCache = function() {
-          var result = Object.assign({}, resolveCache[cacheId]);
+          var result = Object.assign({}, moduleResolveCache[cacheId]);
           result.dependencies = request.dependencies;
           result.parser = compilation.compiler.parser;
           if (!result.parser || !result.parser.parse) {
@@ -1124,8 +1141,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           return cb(null, result);
         };
 
-        if (resolveCache[cacheId]) {
-          var resource = resolveCache[cacheId].resource.split('?')[0];
+        if (moduleResolveCache[cacheId]) {
+          var resource = moduleResolveCache[cacheId].resource.split('?')[0];
           if (fileTimestamps[resource]) {
             return fromCache();
           }
@@ -1296,6 +1313,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     var dataOps = [];
     var md5Ops = [];
     var assetOps = [];
+    var moduleResolveOps = [];
 
     var buildingMd5s = {};
 
@@ -1394,6 +1412,24 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       });
 
       buildMd5Ops(dataCache.contextDependencies);
+
+      moduleResolveCacheChange
+      .reduce(function(carry, value) {
+        if (carry.indexOf(value) === -1) {
+          carry.push(value);
+        }
+        return carry;
+      }, [])
+      .forEach(function(key) {
+        moduleResolveOps.push({
+          key: key,
+          value: moduleResolveCache[key] ?
+            JSON.stringify(moduleResolveCache[key]) :
+            null,
+        });
+      });
+
+      moduleResolveCacheChange = [];
     }
 
     // moduleCache.fileDependencies = compilation.fileDependencies;
@@ -1598,7 +1634,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     Promise.all([
       fsWriteFile(path.join(cacheDirPath, 'stamp'), currentStamp, 'utf8'),
       fsWriteFile(path.join(cacheDirPath, 'version'), hardSourceVersion, 'utf8'),
-      fsWriteFile(resolveCachePath, JSON.stringify(resolveCache), 'utf8'),
+      moduleResolveCacheSerializer.write(moduleResolveOps),
       assetCacheSerializer.write(assetOps),
       moduleCacheSerializer.write(moduleOps),
       dataCacheSerializer.write(dataOps),

--- a/lib/cache-serializer-factory.js
+++ b/lib/cache-serializer-factory.js
@@ -1,0 +1,143 @@
+/**
+ * A factory wrapper around a webpack compiler plugin to create a serializer
+ * object that caches a various data hard-source turns into json data without
+ * circular references.
+ *
+ * The wrapper uses a plugin hook on the webpack Compiler called
+ * `'hard-source-cache-factory'`. It is a waterfall plugin, the returned value
+ * of one plugin handle is passed to the next as the first argument. This
+ * plugin is expected to return a factory function that takes one argument. The
+ * argument passed to the factory function is the info about what kind of cache
+ * serializer hard-source wants.
+ *
+ * The info object contains three fields, `name`, `type`, and `cacheDirPath`.
+ *
+ * One example of info might be
+ *
+ * ```js
+ * {
+ *   name: 'asset',
+ *   type: 'file',
+ *   cacheDirPath: '/absolute/path/to/my-project/path/configured/in/hard-source'
+ * }
+ * ```
+ *
+ * - `name` is the general name of the cache in hard-source.
+ * - `type` is the type of data contained. The `file` type means it'll be file
+ *    data like large buffers and strings. The `data` type means its generally
+ *    smaller info and serializable with JSON.stringify.
+ * - `cacheDirPath` is the root of the hard-source disk cache. A serializer
+ *   should add some further element to the path for where it will store its
+ *   info.
+ *
+ * So an example plugin handle should take the `factory` argument and return
+ * its own wrapping factory function. That function will take the `info` data
+ * and if it wants to returns a serializer. Otherwise its best to call the
+ * factory passed into the plugin handle.
+ *
+ * ```js
+ * compiler.plugin('hard-source-cache-factory', function(factory) {
+ *   return function(info) {
+ *     if (info.type === 'data') {
+ *       return new MySerializer({
+ *         cacheDirPath: join(info.cacheDirPath, info.name)
+ *       });
+ *     }
+ *     return factory(info);
+ *   };
+ * });
+ * ```
+ *
+ * @module hard-source-webpack-plugin/cache-serializer-factory
+ * @author Michael "Z" Goddard <mzgoddard@gmail.com>
+ */
+
+/**
+ * @constructor Serializer
+ * @memberof module:hard-source-webpack-plugin/cache-serializer-factory
+ */
+
+/**
+ * @method read
+ * @memberof module:hard-source-webpack-plugin/cache-serializer-factory~Serializer#
+ * @returns {Promise} promise that resolves the disk cache's contents
+ * @resolves {Object} a map of keys to current values stored on disk that has
+ *   previously been cached
+ */
+
+/**
+ * @method write
+ * @memberof module:hard-source-webpack-plugin/cache-serializer-factory~Serializer#
+ * @param {Array.Object} ops difference of values to be stored in the disk cache
+ * @param {string} ops.key
+ * @param ops.value
+ * @returns {Promise} promise that resolves when writing completes
+ */
+
+var join = require('path').join;
+
+var FileSerializer = require('./cache-serializers').FileSerializer;
+var LevelDbSerializer = require('./cache-serializers').LevelDbSerializer;
+
+/**
+ * @constructor CacheSerializerFactory
+ * @memberof module:hard-source-webpack-plugin/cache-serializer-factory
+ */
+function CacheSerializerFactory(compiler) {
+  this.compiler = compiler;
+
+  compiler.plugin("hard-source-cache-factory", function(factory) {
+    return function(info) {
+      // It's best to have plugins to hard-source listed in the config after it
+      // but to make hard-source easier to use we can call the factory of a
+      // plugin passed into this default factory.
+      if (factory) {
+        serializer = factory(info);
+        if (serializer) {
+          return serializer;
+        }
+      }
+
+      // Otherwise lets return the default serializers.
+      switch (info.type) {
+      case 'data':
+        return new LevelDbSerializer({
+          cacheDirPath: join(info.cacheDirPath, info.name)
+        });
+        break;
+      case 'file':
+        return new FileSerializer({
+          cacheDirPath: join(info.cacheDirPath, info.name)
+        });
+        break;
+      default:
+        throw new Error(
+          'Unknown hard-source cache serializer type: ' + info.type
+        );
+        break;
+      }
+    };
+  });
+}
+
+/**
+ * @method create
+ * @memberof module:hard-source-webpack-plugin/cache-serializer-factory~CacheSerializerFactory#
+ * @param {Object} info
+ * @param {String} info.name
+ * @param {String} info.type
+ * @param {String} info.cacheDirPath
+ * @returns {Serializer}
+ */
+CacheSerializerFactory.prototype.create = function(info) {
+  const factory = (
+    this.compiler.applyPluginsWaterfall0 ||
+    this.compiler.applyPluginsWaterfall
+  ).call(this.compiler, "hard-source-cache-factory", null);
+
+  const serializer = factory(info);
+
+  return serializer;
+};
+
+module.exports = CacheSerializerFactory;

--- a/lib/cache-serializers.js
+++ b/lib/cache-serializers.js
@@ -13,6 +13,7 @@ var fsWriteFile = Promise.promisify(fs.writeFile, {context: fs});
 
 exports.FileSerializer = FileSerializer;
 exports.LevelDbSerializer = LevelDbSerializer;
+exports.JsonSerializer = JsonSerializer;
 
 function FileSerializer(options) {
   this.path = options.cacheDirPath;
@@ -92,5 +93,35 @@ LevelDbSerializer.prototype.write = function(moduleOps) {
   })
   .then(function(db) {
     return Promise.promisify(db.close, {context: db})();
+  });
+};
+
+function JsonSerializer(options) {
+  this.path = options.cacheDirPath;
+  if (!/\.json$/.test(this.path)) {
+    this.path += '.json';
+  }
+}
+
+JsonSerializer.prototype.read = function() {
+  var cacheDirPath = this.path;
+  return Promise.promisify(fs.readFile)(cacheDirPath, 'utf8')
+  .catch(function() {return '{}';})
+  .then(JSON.parse);
+};
+
+JsonSerializer.prototype.write = function(moduleOps) {
+  var cacheDirPath = this.path;
+  return this.read()
+  .then(function(cache) {
+    for (var i = 0; i < moduleOps.length; i++) {
+      var op = moduleOps[i];
+      cache[op.key] = op.value;
+    }
+    return cache;
+  })
+  .then(JSON.stringify)
+  .then(function(cache) {
+    return Promise.promisify(fs.writeFile)(cacheDirPath, cache);
   });
 };

--- a/lib/cache-serializers.js
+++ b/lib/cache-serializers.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 
+var mkdirp = require('mkdirp');
 var level = require('level');
 
 var Promise = require('bluebird');
@@ -20,6 +21,7 @@ function FileSerializer(options) {
 FileSerializer.prototype.read = function() {
   var assets = {};
   var cacheAssetDirPath = this.path;
+  mkdirp.sync(cacheAssetDirPath);
   return Promise.all(fs.readdirSync(cacheAssetDirPath).map(function(name) {
     return fsReadFile(path.join(cacheAssetDirPath, name))
     .then(function(asset) {
@@ -31,6 +33,7 @@ FileSerializer.prototype.read = function() {
 
 FileSerializer.prototype.write = function(assetOps) {
   var cacheAssetDirPath = this.path;
+  mkdirp.sync(cacheAssetDirPath);
   return Promise.all(assetOps.map(function(asset) {
     var assetPath = path.join(cacheAssetDirPath, asset.key);
     return fsWriteFile(assetPath, asset.value);

--- a/lib/hard-source-json-serializer-plugin.js
+++ b/lib/hard-source-json-serializer-plugin.js
@@ -1,0 +1,20 @@
+var join = require('path').join;
+
+var JsonSerializer = require('./cache-serializers').JsonSerializer;
+
+module.exports = HardSourceJsonSerializerPlugin;
+
+function HardSourceJsonSerializerPlugin() {}
+
+HardSourceJsonSerializerPlugin.prototype.apply = function(compiler) {
+  compiler.plugin('hard-source-cache-factory', function(factory) {
+    return function(info) {
+      if (info.type === 'data') {
+        return new JsonSerializer({
+          cacheDirPath: join(info.cacheDirPath, info.name)
+        });
+      }
+      return factory(info);
+    };
+  });
+};

--- a/tests/fixtures/plugin-serializer-json-base-1dep/fib.js
+++ b/tests/fixtures/plugin-serializer-json-base-1dep/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/plugin-serializer-json-base-1dep/index.js
+++ b/tests/fixtures/plugin-serializer-json-base-1dep/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/plugin-serializer-json-base-1dep/webpack.config.js
+++ b/tests/fixtures/plugin-serializer-json-base-1dep/webpack.config.js
@@ -1,0 +1,20 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+    new HardSourceWebpackPlugin.HardSourceJsonSerializerPlugin(),
+  ],
+};

--- a/tests/plugins-webpack-1.js
+++ b/tests/plugins-webpack-1.js
@@ -30,11 +30,13 @@ describe('plugin webpack use', function() {
   itCompilesTwice('plugin-ignore-context-members');
   itCompilesTwice('plugin-child-compiler-resolutions');
   itCompilesTwice('plugin-logger-child-no-memory');
+  itCompilesTwice('plugin-serializer-json-base-1dep');
 
   itCompilesHardModules('plugin-dll', ['./fib.js']);
   itCompilesHardModules('plugin-dll-reference', ['./index.js']);
   itCompilesHardModules('plugin-dll-reference-scope', ['./index.js']);
   itCompilesHardModules('plugin-html-lodash', [/lodash\/lodash\.js$/, /\!\.\/index\.html$/]);
+  itCompilesHardModules('plugin-serializer-json-base-1dep', ['./fib.js', './index.js']);
 
 });
 


### PR DESCRIPTION
Related to #53

A simple CacheSerializerFactory plugin looks like

```js
class HSCachePlugin {
  apply(compiler) {
    compiler.plugin('hard-source-cache-factory', factory => {
      return info => {
        if (info.type === 'data') {
          return new JsonSerializer({
            cacheDirPath: join(info.cacheDirPath, info.name),
          });
        }
        return factory(info);
      };
    });
  }
}
```

The simplest serializer JsonSerializer can be used by adding this plugin

```js
module.exports = {
  // other webpack config
  plugins: [
    new HardSourceWebpackPlugin(),
    new HardSourceWebpackPlugin.HardSourceJsonSerializerPlugin(),
  ],
};
```

The JsonSerializer makes a nice serializer example

```js
function JsonSerializer(options) {
  this.path = options.cacheDirPath;
  if (!/\.json$/.test(this.path)) {
    this.path += '.json';
  }
}

JsonSerializer.prototype.read = function() {
  var cacheDirPath = this.path;
  return bluebird.promisify(fs.readFile)(cacheDirPath, 'utf8')
  .catch(function() {return '{}';})
  .then(JSON.parse);
};

JsonSerializer.prototype.write = function(moduleOps) {
  var cacheDirPath = this.path;
  return this.read()
  .then(function(cache) {
    for (var i = 0; i < moduleOps.length; i++) {
      var op = moduleOps[i];
      cache[op.key] = op.value;
    }
    return cache;
  })
  .then(JSON.stringify)
  .then(function(cache) {
    return bluebird.promisify(fs.writeFile)(cacheDirPath, cache);
  });
};
```