### PR TITLE
Cache low level resolutions and checked (missing) attempts

### DIFF
--- a/index.js
+++ b/index.js
@@ -434,6 +434,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var dataCache = {};
   var moduleResolveCache = {};
   var md5Cache = {};
+  var missingCache = {normal: {},loader: {},context: {}};
   var currentStamp = '';
 
   var moduleResolveCacheChange = [];
@@ -451,6 +452,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var dataCacheSerializer;
   var md5CacheSerializer;
   var moduleResolveCacheSerializer;
+  var missingCacheSerializer;
 
   var _this = this;
 
@@ -497,7 +499,8 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       .catch(function() {return '';});
     };
 
-    contextStamps = function(contextDependencies, fileDependencies) {
+    contextStamps = function(contextDependencies, fileDependencies, stats) {
+      stats = stats || {};
       var contexts = {};
       contextDependencies.forEach(function(context) {
         contexts[context] = {files: [], mtime: 0, hash: ''};
@@ -519,7 +522,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           return readdir(dir)
           .then(function(items) {
             return Promise.all(items.map(function(item) {
-              return stat(path.join(dir, item))
+              var file = path.join(dir, item);
+              if (!stats[file]) {stats[file] = stat(file);}
+              return stats[file]
               .then(function(stat) {
                 if (stat.isDirectory()) {
                   return walk(path.join(dir, item))
@@ -619,6 +624,11 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           type: 'data',
           cacheDirPath: cacheDirPath,
         });
+        missingCacheSerializer = cacheSerializerFactory.create({
+          name: 'missing-resolve',
+          type: 'data',
+          cacheDirPath: cacheDirPath,
+        });
       }
       catch (err) {
         return cb(err);
@@ -672,6 +682,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         dataCache = {};
         moduleResolveCache = {};
         md5Cache = {};
+        missingCache = {normal: {},loader: {},context: {}};
         fileTimestamps = {};
         contextTimestamps = {};
         return;
@@ -720,6 +731,21 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
             }
           });
         }),
+
+        missingCacheSerializer.read()
+        .then(function(_missingCache) {
+          missingCache = {normal: {},loader: {},context: {}};
+          Object.keys(_missingCache).forEach(function(key) {
+            var item = _missingCache[key];
+            if (typeof item === 'string') {
+              item = JSON.parse(item);
+            }
+            var splitIndex = key.indexOf('/');
+            var group = key.substring(0, splitIndex);
+            var keyName = key.substring(splitIndex + 1);
+            missingCache[group][keyName] = item;
+          });
+        }),
       ])
       .then(function() {
         // console.log('cache in', Date.now() - start);
@@ -750,9 +776,11 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       };
     }
 
+    var stats = {};
     return Promise.all([
       Promise.all(dataCache.fileDependencies.map(function(file) {
-        return stat(file)
+        if (!stats[file]) {stats[file] = stat(file);}
+        return stats[file]
         .then(function(stat) {return +stat.mtime;})
         .then(setKey(fileTs, file, 0), setKeyError(fileTs, file, 0))
         .then(function() {
@@ -772,7 +800,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       })),
       new Promise(function(resolve, reject) {
         var contextTs = compiler.contextTimestamps = contextTimestamps = {};
-        return contextStamps(dataCache.contextDependencies, dataCache.fileDependencies)
+        return contextStamps(dataCache.contextDependencies, dataCache.fileDependencies, stats)
         .then(function(contexts) {
           for (var contextPath in contexts) {
             var context = contexts[contextPath];
@@ -784,6 +812,35 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         })
         .then(resolve, reject);
       }),
+      (function() {
+        var handles = [];
+        Object.keys(missingCache).map(function(group) {
+          Object.keys(missingCache[group]).map(function(key) {
+            var missingItem = missingCache[group][key];
+            if (!missingItem) {return;}
+            missingItem.map(function(missed, index) {
+              var missedPath = missed.split('?')[0];
+              if (index === missingItem.length - 1) {
+                if (!stats[missed]) {stats[missed] = stat(missed);}
+                return handles.push(stats[missed]
+                .catch(function() {missingItem.invalid = true;}));
+              }
+              if (!stats[missed]) {stats[missed] = stat(missed);}
+              return handles.push(stats[missed]
+              .then(function(stat) {
+                if (stat.isDirectory()) {
+                  if (group === 'context') {missingItem.invalid = true;}
+                }
+                if (stat.isFile()) {
+                  if (group === 'loader' || group === 'normal') {missingItem.invalid = true;}
+                }
+              })
+              .catch(function() {}));
+            });
+          });
+        });
+        return handles;
+      })(),
     ])
     .then(function() {cb();}, cb);
   });
@@ -1003,6 +1060,78 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     }
   }
 
+  compiler.plugin('after-plugins', function() {
+    function configureMissing(key, resolver) {
+      missingCache[key] = {};
+
+      var _resolve = resolver.resolve;
+      resolver.resolve = function(info, context, request, cb) {
+        var numArgs = 4;
+        if (!cb) {
+          numArgs = 3;
+          cb = request;
+          request = context;
+          context = info;
+        }
+        var localMissing = [];
+        var callback = function(err, result) {
+          if (result) {
+            var inverseId = JSON.stringify([context, result.split('?')[0]]);
+            var resolveId = JSON.stringify([context, request]);
+
+            // Skip recording missing for any dependency in node_modules.
+            // Changes to them will be handled by the environment hash. If we
+            // tracked the stuff in node_modules too, we'd be adding a whole
+            // bunch of reduntant work.
+            if (result.indexOf('node_modules') !== -1) {
+              localMissing = [];
+            }
+
+            // In case of other cache layers, if we already have missing
+            // recorded and we get a new empty array of missing, keep the old
+            // value.
+            if (localMissing.length === 0 && missingCache[key][inverseId]) {
+              return cb(err, result);
+            }
+
+            missingCache[key][inverseId] = localMissing.filter(function(missed, missedIndex) {
+              var index = localMissing.indexOf(missed);
+              if (index === -1 || index < missedIndex) {
+                return false;
+              }
+              if (missed === result) {
+                return false;
+              }
+              return true;
+            }).concat(result.split('?')[0]);
+            missingCache[key][resolveId].new = true;
+          }
+          cb(err, result);
+        };
+        if (callback.missing) {
+          var _missing = callback.missing;
+          callback.missing = {push: function(path) {
+            localMissing.push(path);
+            _missing.push(path);
+          }};
+        }
+        else {
+          callback.missing = localMissing;
+        }
+        if (numArgs === 3) {
+          _resolve.call(this, context, request, callback);
+        }
+        else {
+          _resolve.call(this, info, context, request, callback);
+        }
+      };
+    }
+
+    configureMissing('normal', compiler.resolvers.normal);
+    configureMissing('loader', compiler.resolvers.loader);
+    configureMissing('context', compiler.resolvers.context);
+  });
+
   compiler.plugin('compilation', function(compilation, params) {
     if (!active) {return;}
 
@@ -1050,7 +1179,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         )) {
           // Bust this module, the keys exported or their order has changed.
           cacheItem.invalid = true;
-          moduleCache[identifier] = null;
+          // moduleCache[identifier] = null;
 
           // Bust all dependents, they likely need to use new keys for this
           // module.
@@ -1059,7 +1188,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
             var reasonItem = moduleCache[identifier];
             if (reasonItem) {
               reasonItem.invalid = true;
-              moduleCache[identifier] = null;
+              // moduleCache[identifier] = null;
             }
             if (reason.dependency.__NormalModuleFactoryCache) {
               reason.dependency.__NormalModuleFactoryCache = null;
@@ -1144,13 +1273,11 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           return cb(null, result);
         };
 
-        if (moduleResolveCache[cacheId]) {
-          var resource = moduleResolveCache[cacheId].resource.split('?')[0];
-          if (fileTimestamps[resource]) {
-            return fromCache();
-          }
-          return stat(resource)
-          .then(fromCache, next);
+        if (
+          moduleResolveCache[cacheId] &&
+          !moduleResolveCache[cacheId].invalid
+        ) {
+          return fromCache();
         }
 
         next();
@@ -1317,6 +1444,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
     var md5Ops = [];
     var assetOps = [];
     var moduleResolveOps = [];
+    var missingOps = [];
 
     var buildingMd5s = {};
 
@@ -1433,6 +1561,37 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       });
 
       moduleResolveCacheChange = [];
+
+      Object.keys(missingCache).forEach(function(group) {
+        Object.keys(missingCache[group]).forEach(function(key) {
+          if (!missingCache[group][key]) {return;}
+          if (missingCache[group][key].new) {
+            missingCache[group][key].new = false;
+            missingOps.push({
+              key: group + '/' + key,
+              value: JSON.stringify(missingCache[group][key]),
+            });
+          }
+          else if (missingCache[group][key].invalid) {
+            missingCache[group][key] = null;
+            missingOps.push({
+              key: group + '/' + key,
+              value: null,
+            });
+          }
+        });
+      });
+
+      Object.keys(moduleCache).forEach(function(key) {
+        var cacheItem = moduleCache[key];
+        if (cacheItem && cacheItem.invalid) {
+          moduleCache[key] = null;
+          moduleOps.push({
+            key: key,
+            value: null,
+          });
+        }
+      });
     }
 
     // moduleCache.fileDependencies = compilation.fileDependencies;
@@ -1642,6 +1801,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       moduleCacheSerializer.write(moduleOps),
       dataCacheSerializer.write(dataOps),
       writeMd5Ops,
+      missingCacheSerializer.write(missingOps),
     ])
     .then(function() {
       // console.log('cache out', Date.now() - startCacheTime);

--- a/index.js
+++ b/index.js
@@ -750,38 +750,41 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       };
     }
 
-    return Promise.all(dataCache.fileDependencies.map(function(file) {
-      return stat(file)
-      .then(function(stat) {return +stat.mtime;})
-      .then(setKey(fileTs, file, 0), setKeyError(fileTs, file, 0))
-      .then(function() {
-        var setter = setKey(fileMd5s, file, '');
-        if (
-          md5Cache[file] && fileTs[file] >= md5Cache[file].mtime ||
-          !md5Cache[file] ||
-          !fileTs[file]
-        ) {
-          return md5(file)
-          .then(setter, setKeyError(fileMd5s, file, ''));
-        }
-        else {
-          setter(md5Cache[file].hash);
-        }
-      });
-    }))
-    .then(function() {
-      var contextTs = compiler.contextTimestamps = contextTimestamps = {};
-      return contextStamps(dataCache.contextDependencies, dataCache.fileDependencies)
-      .then(function(contexts) {
-        for (var contextPath in contexts) {
-          var context = contexts[contextPath];
+    return Promise.all([
+      Promise.all(dataCache.fileDependencies.map(function(file) {
+        return stat(file)
+        .then(function(stat) {return +stat.mtime;})
+        .then(setKey(fileTs, file, 0), setKeyError(fileTs, file, 0))
+        .then(function() {
+          var setter = setKey(fileMd5s, file, '');
+          if (
+            md5Cache[file] && fileTs[file] >= md5Cache[file].mtime ||
+            !md5Cache[file] ||
+            !fileTs[file]
+          ) {
+            return md5(file)
+            .then(setter, setKeyError(fileMd5s, file, ''));
+          }
+          else {
+            setter(md5Cache[file].hash);
+          }
+        });
+      })),
+      new Promise(function(resolve, reject) {
+        var contextTs = compiler.contextTimestamps = contextTimestamps = {};
+        return contextStamps(dataCache.contextDependencies, dataCache.fileDependencies)
+        .then(function(contexts) {
+          for (var contextPath in contexts) {
+            var context = contexts[contextPath];
 
-          fileTimestamps[contextPath] = context.mtime;
-          contextTimestamps[contextPath] = context.mtime;
-          fileMd5s[contextPath] = context.hash;
-        }
-      });
-    })
+            // fileTimestamps[contextPath] = context.mtime;
+            contextTimestamps[contextPath] = context.mtime;
+            fileMd5s[contextPath] = context.hash;
+          }
+        })
+        .then(resolve, reject);
+      }),
+    ])
     .then(function() {cb();}, cb);
   });
 

--- a/lib/cache-serializers.js
+++ b/lib/cache-serializers.js
@@ -78,7 +78,12 @@ LevelDbSerializer.prototype.write = function(moduleOps) {
   }
 
   for (var i = 0; i < ops.length; i++) {
-    ops.type = 'put';
+    if (ops[i].value === null) {
+      ops[i].type = 'delete';
+    }
+    else {
+      ops[i].type = 'put';
+    }
   }
 
   var cachePath = this.path;

--- a/lib/hard-context-module-factory.js
+++ b/lib/hard-context-module-factory.js
@@ -39,9 +39,9 @@ HardContextModuleFactory.prototype.create = function(context, dependency, callba
     regExp: dependency.regExp ? dependency.regExp.source : null,
     async: dependency.async,
   });
-  if (resolveCache[resolveIdentifier]) {
+  if (resolveCache[resolveIdentifier] && !resolveCache[resolveIdentifier].invalid) {
     var cacheItem = moduleCache[resolveCache[resolveIdentifier].identifier];
-    if (cacheItem) {
+    if (cacheItem && !cacheItem.invalid) {
       if (!HardContextModule.needRebuild(
         cacheItem,
         fileTimestamps,
@@ -79,6 +79,7 @@ HardContextModuleFactory.prototype.create = function(context, dependency, callba
     }
     var identifier = identifierPrefix + module.identifier();
     resolveCache[resolveIdentifier] = {
+      type: 'context',
       identifier: identifier,
       resource: module.context,
     };

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -192,4 +192,17 @@ describe('basic webpack use - builds changes', function() {
     expect(output.run2['main.js'].toString()).to.not.match(/exports = 1;/);
   });
 
+  itCompilesChange('base-resolve-missing', {
+    'fib.js': null,
+  }, {
+    'fib.js': [
+      'module.exports = function(n) {',
+      '  return n + (n > 0 ? n - 2 : 0);',
+      '};',
+    ].join('\n'),
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/n - 1/);
+    expect(output.run2['main.js'].toString()).to.match(/n - 2/);
+  });
+
 });

--- a/tests/fixtures/base-resolve-missing/fib.js
+++ b/tests/fixtures/base-resolve-missing/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 2 : 0);
+};

--- a/tests/fixtures/base-resolve-missing/fib/index.js
+++ b/tests/fixtures/base-resolve-missing/fib/index.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-resolve-missing/index.js
+++ b/tests/fixtures/base-resolve-missing/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/base-resolve-missing/webpack.config.js
+++ b/tests/fixtures/base-resolve-missing/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/loader-custom-resolve-missing-query/fib.js
+++ b/tests/fixtures/loader-custom-resolve-missing-query/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 2 : 0);
+};

--- a/tests/fixtures/loader-custom-resolve-missing-query/fib/index.js
+++ b/tests/fixtures/loader-custom-resolve-missing-query/fib/index.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/loader-custom-resolve-missing-query/index.js
+++ b/tests/fixtures/loader-custom-resolve-missing-query/index.js
@@ -1,0 +1,3 @@
+var fib = require('./loader?missing!./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/loader-custom-resolve-missing-query/loader/index.js
+++ b/tests/fixtures/loader-custom-resolve-missing-query/loader/index.js
@@ -1,0 +1,7 @@
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  return [
+    '// loader/index.js',
+    source,
+  ].join('\n');
+};

--- a/tests/fixtures/loader-custom-resolve-missing-query/webpack.config.js
+++ b/tests/fixtures/loader-custom-resolve-missing-query/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/fixtures/loader-custom-resolve-missing/fib.js
+++ b/tests/fixtures/loader-custom-resolve-missing/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 2 : 0);
+};

--- a/tests/fixtures/loader-custom-resolve-missing/fib/index.js
+++ b/tests/fixtures/loader-custom-resolve-missing/fib/index.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/loader-custom-resolve-missing/index.js
+++ b/tests/fixtures/loader-custom-resolve-missing/index.js
@@ -1,0 +1,3 @@
+var fib = require('./loader!./fib');
+
+console.log(fib(3));

--- a/tests/fixtures/loader-custom-resolve-missing/loader.js
+++ b/tests/fixtures/loader-custom-resolve-missing/loader.js
@@ -1,0 +1,7 @@
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  return [
+    '// loader.js',
+    source,
+  ].join('\n');
+};

--- a/tests/fixtures/loader-custom-resolve-missing/loader/index.js
+++ b/tests/fixtures/loader-custom-resolve-missing/loader/index.js
@@ -1,0 +1,7 @@
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+  return [
+    '// loader/index.js',
+    source,
+  ].join('\n');
+};

--- a/tests/fixtures/loader-custom-resolve-missing/webpack.config.js
+++ b/tests/fixtures/loader-custom-resolve-missing/webpack.config.js
@@ -1,0 +1,19 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  recordsPath: __dirname + '/tmp/cache/records.json',
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentPaths: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -131,4 +131,51 @@ describe('loader webpack use - builds changes', function() {
     expect(output.run2['main.js'].toString()).to.not.match(/fib\.js/);
   });
 
+  itCompilesChange('loader-custom-resolve-missing', {
+    'fib.js': null,
+    'loader.js': null,
+  }, {
+    'fib.js': [
+      'module.exports = function(n) {',
+      '  return n + (n > 0 ? n - 2 : 0);',
+      '};',
+    ].join('\n'),
+    'loader.js': null,
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/n - 1/);
+    expect(output.run2['main.js'].toString()).to.match(/n - 2/);
+  });
+
+  itCompilesChange('loader-custom-resolve-missing', {
+    'loader.js': null,
+  }, {
+    'loader.js': [
+      'module.exports = function(source) {',
+      '  this.cacheable && this.cacheable();',
+      '  return [',
+      '    \'// loader.js\',',
+      '    source,',
+      '  ].join(\'\\n\');',
+      '};',
+    ].join('\n'),
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/loader\/index\.js/);
+    expect(output.run2['main.js'].toString()).to.match(/loader\.js/);
+  });
+
+  itCompilesChange('loader-custom-resolve-missing-query', {
+    'fib.js': null,
+    'loader.js': null,
+  }, {
+    'fib.js': [
+      'module.exports = function(n) {',
+      '  return n + (n > 0 ? n - 2 : 0);',
+      '};',
+    ].join('\n'),
+    'loader.js': null,
+  }, function(output) {
+    expect(output.run1['main.js'].toString()).to.match(/n - 1/);
+    expect(output.run2['main.js'].toString()).to.match(/n - 2/);
+  });
+
 });


### PR DESCRIPTION
Cahe low level resolutions for the normal, loader, and context resolvers. These resolvers can be used multiple times for the same input and output as long they have a different input. Like a normal resolution will resolve the same file if it was requested with a different set of loaders. Alongside this cache the missing paths that were attempted. These can be checked to invalidate the low level resolutions and the normal module factory resolutions. This accounts for when files are moved and changed without the original resolution changing.

To reduce the checking on the missing cache, exclude areas already covered by the environment hash like node_modules. Files in node_modules will regularly have multiple missing attempts and when they change the environment hash will detect it and be a better use of time to figure that out.

In the end this provide an oppurtunity for performance gains with the low level resolver cache and increated validation that the built output correctly reflects the intended input.