### PR TITLE
Test that loader use works in watch mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -913,7 +913,9 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
               // webpack searches for rule based loaders from the project
               // context.
               loaderMissing = missingCache.loader[JSON.stringify([
-                compiler.options.context,
+                // compiler may be a Watching instance, which refers to the
+                // compiler
+                (compiler.options || compiler.compiler.options).context,
                 loader.split('?')[0]
               ])];
             }

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -230,3 +230,18 @@ describe('loader webpack use - builds changes', function() {
   );
 
 });
+
+describe('loader webpack use - watch mode', function() {
+
+  it('loader-file-use: compiles in watch mode', function(done) {
+    compile('loader-file-use', {watch: 'startStop'})
+    .then(function(result) {
+      return compile('loader-file-use', {watch: 'startStop'});
+    })
+    .then(function(result) {
+      done();
+    })
+    .catch(done);
+  });
+
+});


### PR DESCRIPTION
Fix #148

- If in a watch-run dereference the compiler from the Watching instance
  to get the context when checking if missing paths for a loader now
  exist

Webpack in watch mode creates a Watching instance that is in charge of
starting compiler runs. In this case the 'watch-run' plugin hook is
called instead of the 'run' hook. Instead of getting a compiler the
'watch-run' hook gets the Watching instance and if the compiler is
desired must be dereferenced from the Watching instance.