### PR TITLE
LICENSE: add title and extension

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+## ISC License
+
 Copyright (c) 2016, Michael "Z" Goddard <mzgoddard@gmail.com>
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.


### PR DESCRIPTION
The title is not legally mandated, but it's convenient for human consumption; it also works as additional metadata, and is part of the recommended license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license).

The extension is needed to trigger github's soft-wrapping rendering mode. This also allows the title to be highlighted with the appropriate semantic markup (a markdown heading).

*This PR is part of a project to improve the consistency and visibility of the ISC license. See https://github.com/github/choosealicense.com/issues/377 for more details.*