### PR TITLE
Add support for webpack 3.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mocha": "^3.0.2",
     "rimraf": "^2.5.4",
     "style-loader": "^0.14.0",
-    "webpack": "^3.0.0 || ^3.0.0-rc.0 || ^2.1.0 || ^1.13.1",
+    "webpack": "^3.8.1 || ^3.0.0 || ^3.0.0-rc.0 || ^2.1.0 || ^1.13.1",
     "webpack-isomorphic-tools": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes #184 — looks like the webpack dependency just needed bumping.

I've tested this locally and it resolves my issue. Some of the unit tests are failing for me, but the same tests fail on master ¯\_(ツ)_/¯

Let me know if there's anything else you want changed. Cheers!
