### PR TITLE
Add current node to travis and fix failing webpack 3 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ language: node_js
 matrix:
   fast_finish: true
   include:
-    - node_js: 7
+    - node_js: node
+      env: WEBPACK_VERSION=3 EXTRACT_TEXT_VERSION=2 BABEL_LOADER=7 FILE_LOADER=0.11
+    - node_js: 8
       env: WEBPACK_VERSION=1 EXTRACT_TEXT_VERSION=1 BABEL_LOADER=6 FILE_LOADER=0.10
-    - node_js: 7
+    - node_js: 8
       env: WEBPACK_VERSION=2 EXTRACT_TEXT_VERSION=2 BABEL_LOADER=7 FILE_LOADER=0.11
-    - node_js: 7
+    - node_js: 8
       env: WEBPACK_VERSION=3 EXTRACT_TEXT_VERSION=2 BABEL_LOADER=7 FILE_LOADER=0.11
     - node_js: 4
       env: WEBPACK_VERSION=1 EXTRACT_TEXT_VERSION=1 BABEL_LOADER=6 FILE_LOADER=0.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - node_js: 4
   include:
     - node_js: node
       env: WEBPACK_VERSION=3 EXTRACT_TEXT_VERSION=2 BABEL_LOADER=7 FILE_LOADER=0.11

--- a/lib/deserialize-dependencies.js
+++ b/lib/deserialize-dependencies.js
@@ -19,7 +19,7 @@ exports.blocks = deserializeBlocks;
 function deserializeDependencies(deps, parent) {
   return deps.map(function(req) {
     if (req.contextDependency) {
-      var dep = new HardContextDependency(req.request, req.recursive, req.regExp ? new RegExp(req.regExp) : null);
+      var dep = new HardContextDependency(req.request, req.recursive, req.regExp ? new RegExp(req.regExp) : false);
       dep.critical = req.contextCritical;
       dep.async = req.async;
       dep.loc = req.loc;

--- a/lib/hard-basic-dependency-plugin.js
+++ b/lib/hard-basic-dependency-plugin.js
@@ -29,7 +29,7 @@ HardBasicDependencyPlugin.prototype.apply = function(compiler) {
         critical: dependency.critical,
         request: dependency.request,
         recursive: dependency.recursive,
-        regExp: dependency.regExp ? dependency.regExp.source : null,
+        regExp: dependency.regExp ? dependency.regExp.source : false,
         async: dependency.async,
         optional: dependency.optional,
       };
@@ -110,7 +110,7 @@ HardBasicDependencyPlugin.prototype.apply = function(compiler) {
 
   compiler.plugin('--hard-source-thaw-dependency', function(dependency, frozen, extra) {
     if (frozen.type === 'ContextDependency') {
-      dependency = new HardContextDependency(frozen.request, frozen.recursive, frozen.regExp ? new RegExp(frozen.regExp) : null);
+      dependency = new HardContextDependency(frozen.request, frozen.recursive, frozen.regExp ? new RegExp(frozen.regExp) : false);
       dependency.critical = frozen.critical;
       dependency.async = frozen.async;
       if (frozen.optional) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -53,6 +53,26 @@ function cachePrefix(compilation) {
           break;
         }
       }
+      // webpack 3 adds the children member containing compiler names paired
+      // with arrays of compilation caches, one for each compilation sharing the
+      // same name.
+      if (!cacheKey && parentCache.children) {
+        parentCache = parentCache.children;
+        for (var key in parentCache) {
+          if (key && parentCache[key]) {
+            for (var index in parentCache[key]) {
+              if (parentCache[key][index] === cache) {
+                cacheKey = key + '.' + index;
+                break;
+              }
+              if (parentCache[key][index][nextCompilation.compiler.name] === cache) {
+                cacheKey = key + '.' + index + '.' + nextCompilation.compiler.name;
+                break;
+              }
+            }
+          }
+        }
+      }
 
       if (!cacheKey) {
         if (cachePrefixErrorOnce) {

--- a/tests/plugins-webpack-2.js
+++ b/tests/plugins-webpack-2.js
@@ -25,9 +25,23 @@ describeWP2('plugin webpack 2 use - builds changes', function() {
     var run2Module = run2Ids[1];
     var run2Require = run2Ids[2];
     expect(main1).to.contain(run1Module + '.a');
-    expect(main1).to.not.match(new RegExp(run1Require + '\\.i\\(' + run1Module + '\\.a\\)\\(|' + run1Module + '\\.a\\('));
+    expect(main1).to.not.match(new RegExp(
+      // webpack 2.x
+      run1Require + '\\.i\\(' + run1Module + '\\.a\\)\\(|' +
+      // webpack <3.?
+      run1Module + '\\.a\\(|' +
+      // webpack 3.?
+      'Object\\(' + run1Module + '\\.a\\)\\('
+    ));
     expect(main1).to.not.match(/(\w\.a)=function/);
-    expect(main2).to.match(new RegExp(run2Require + '\\.i\\(' + run2Module + '\\.a\\)\\(|' + run2Module + '\\.a\\('));
+    expect(main2).to.match(new RegExp(
+      // webpack 2.x
+      run2Require + '\\.i\\(' + run2Module + '\\.a\\)\\(|' +
+      // webpack <3.?
+      run2Module + '\\.a\\(|' +
+      // webpack 3.?
+      'Object\\(' + run2Module + '\\.a\\)\\('
+    ));
     expect(main2).to.match(/(\w\.a)=function/);
   });
 

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -142,7 +142,6 @@ exports.compile = function(fixturePath, options) {
       return carry;
     }, {})
     .then(function(carry) {
-      // console.log(stats.toJson());
       if (options && options.exportStats) {
         var statsJson = stats.toJson({
           errors: true,
@@ -399,7 +398,6 @@ exports.itCompilesHardModules = function(fixturePath, filesA, filesB, expectHand
       return expectHandle(out, hardModules);
     }
     else {
-      // console.log(hardModules);
       expectHandle.forEach(function(handle) {
         if (handle instanceof RegExp) {
           expect(hardModules).to.satisfy(function(modules) {


### PR DESCRIPTION
- Add current node to travis. (Thanks to #140 @JLHwung for bringing this up)
- Fix webpack 3 ContextDependency issue with non-regexp ContextModules
- Fix webpack 3 uglify test relating to es2015 tree shaking support
- Fix child compiler cache prefix search issue