### PR TITLE
Freeze and thaw ImportSpecifier importedVar

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -155,10 +155,10 @@ HardHarmonyImportDependency.prototype.getReference = function() {
   };
 };
 
-function HardHarmonyImportSpecifierDependency(importDependency, id, name, range, strictExportPresence) {
+function HardHarmonyImportSpecifierDependency(importDependency, importedVar, id, name, range, strictExportPresence) {
   Object.setPrototypeOf(this,
     Object.setPrototypeOf(
-      new HarmonyImportSpecifierDependency(importDependency, null, id, name, range, strictExportPresence),
+      new HarmonyImportSpecifierDependency(importDependency, importedVar, id, name, range, strictExportPresence),
       HardHarmonyImportSpecifierDependency.prototype
     )
   );

--- a/lib/hard-harmony-dependency-plugin.js
+++ b/lib/hard-harmony-dependency-plugin.js
@@ -62,6 +62,7 @@ HardHarmonyDependencyPlugin.prototype.apply = function(compiler) {
       return {
         type: 'HarmonyImportSpecifierDependency',
         importDependency: freeze('dependency', null, dependency.importDependency, extra),
+        importedVar: dependency.importedVar,
         id: dependency.id,
         name: dependency.name,
         range: dependency.range,
@@ -140,6 +141,7 @@ HardHarmonyDependencyPlugin.prototype.apply = function(compiler) {
     else if (frozen.type === 'HarmonyImportSpecifierDependency') {
       return new HardHarmonyImportSpecifierDependency(
         thaw('dependency', null, frozen.importDependency, extra),
+        frozen.importedVar,
         frozen.id,
         frozen.name,
         frozen.range,

--- a/lib/hard-harmony-dependency-plugin.js
+++ b/lib/hard-harmony-dependency-plugin.js
@@ -128,10 +128,11 @@ HardHarmonyDependencyPlugin.prototype.apply = function(compiler) {
       );
     }
     else if (frozen.type === 'HarmonyImportDependency') {
-      if (state.imports[frozen.request]) {
-        return state.imports[frozen.request];
+      var ref = frozen.request + frozen.importedVar;
+      if (state.imports[ref]) {
+        return state.imports[ref];
       }
-      return state.imports[frozen.request] =
+      return state.imports[ref] =
         new HardHarmonyImportDependency(
           frozen.request,
           frozen.importedVar,


### PR DESCRIPTION
This finishes up persisting importedVar for harmony dependencies.