### PR TITLE
AppendSerializer performance

### DIFF
--- a/lib/hard-source-append-serializer.js
+++ b/lib/hard-source-append-serializer.js
@@ -5,18 +5,30 @@ var Readable = require('stream').Readable;
 var _mkdirp = require('mkdirp');
 var _rimraf = require('rimraf');
 var writeJsonFile = require('write-json-file');
-var Promise = require('bluebird');
 
-var rimraf = Promise.promisify(_rimraf);
-var open = Promise.promisify(fs.open);
-var close = Promise.promisify(fs.close);
-var read = Promise.promisify(fs.read);
-var readFile = Promise.promisify(fs.readFile);
-var write = Promise.promisify(fs.write);
-var rename = Promise.promisify(fs.rename);
-var unlink = Promise.promisify(fs.unlink);
-var stat = Promise.promisify(fs.stat);
-var mkdirp = Promise.promisify(_mkdirp);
+function promisify(f) {
+  return function() {
+    var args = Array.from(arguments);
+    return new Promise(function(resolve, reject) {
+      args.push(function(err, value) {
+        if (err) {return reject(err);}
+        return resolve(value);
+      });
+      f.apply(null, args);
+    });
+  };
+}
+
+var rimraf = promisify(_rimraf);
+var open = promisify(fs.open);
+var close = promisify(fs.close);
+var read = promisify(fs.read);
+var readFile = promisify(fs.readFile);
+var write = promisify(fs.write);
+var rename = promisify(fs.rename);
+var unlink = promisify(fs.unlink);
+var stat = promisify(fs.stat);
+var mkdirp = promisify(_mkdirp);
 
 module.exports = AppendSerializer;
 
@@ -133,6 +145,10 @@ var _openLog = function(_this, mode, _table, index) {
     })
     .then(function(fd) {
       _this._fd = fd;
+      if (mode === 'a') {
+        _this._writeBuffer = new Buffer(_table.logSize - (index % (_table.logSize / _table.blockSize)) * _table.blockSize);
+        _this._writeOffset = 0;
+      }
     })
     .catch(function(e) {
       throw e;
@@ -143,9 +159,19 @@ var _openLog = function(_this, mode, _table, index) {
 var _closeLog = function(_this) {
   if (_this._fd === null) {return Promise.resolve();}
   else {
-    return close(_this._fd)
+    return Promise.resolve()
+    .then(function() {
+      if (_this._writeBuffer) {
+        return write(_this._fd, _this._writeBuffer, 0, _this._writeOffset);
+      }
+    })
+    .then(function() {
+      return close(_this._fd);
+    })
     .then(function() {
       _this._fd = null;
+      _this._writeBuffer = null;
+      _this._writeOffset = 0;
     });
   }
 };
@@ -202,30 +228,66 @@ var _readLog = function(_this, _table) {
   return out;
 };
 
-var _appendBlock = function(_this, _table, blockContent, index) {
-  return Promise.resolve()
-  .then(function() {
-    if (index % (_table.logSize / _table.blockSize) === 0) {
-      return _closeLog(_this);
-    }
-  })
-  .then(function() {
-    return _openLog(_this, 'a', _table, index);
-  })
-  .then(function() {
+var _appendBlock = function(_this, _table, blockContent, index, next) {
+  var prep;
+  if (_this._fd !== null && index % (_table.logSize / _table.blockSize) === 0) {
+    prep = _closeLog(_this)
+    .then(function() {
+      return _openLog(_this, 'a', _table, index);
+    });
+  }
+  else if (_this._fd === null) {
+    prep = _openLog(_this, 'a', _table, index);
+  }
+  function work() {
     if (!_this._fd) {
-      throw new Error();
+      return next(new Error());
     }
     if (blockContent.length > _table.blockSize) {
-      throw new Error('block longer than max size');
+      return next(new Error('block longer than max size'));
     }
     if (blockContent.length < _table.blockSize) {
       var _blockContent = new Buffer(_table.blockSize);
       blockContent.copy(_blockContent);
       blockContent = _blockContent;
     }
-    return write(_this._fd, blockContent, 0, _table.blockSize);
-  });
+    blockContent.copy(
+      _this._writeBuffer.slice(_this._writeOffset, _this._writeOffset + _table.blockSize)
+    );
+    _this._writeOffset += _table.blockSize;
+    next();
+    // return fs.write(_this._fd, blockContent, 0, _table.blockSize, next);
+  }
+  if (prep) {
+    prep.then(work);
+  }
+  else {
+    work();
+  }
+
+  // return Promise.resolve()
+  // .then(function() {
+  //   if (index % (_table.logSize / _table.blockSize) === 0) {
+  //     return _closeLog(_this);
+  //   }
+  // })
+  // .then(function() {
+  //   return _openLog(_this, 'a', _table, index);
+  // })
+  // .then(function() {
+  //   if (!_this._fd) {
+  //     throw new Error();
+  //   }
+  //   if (blockContent.length > _table.blockSize) {
+  //     throw new Error('block longer than max size');
+  //   }
+  //   if (blockContent.length < _table.blockSize) {
+  //     var _blockContent = new Buffer(_table.blockSize);
+  //     blockContent.copy(_blockContent);
+  //     blockContent = _blockContent;
+  //   }
+  //   return write(_this._fd, blockContent, 0, _table.blockSize);
+  // });
 };
 
 var values = function(obj) {
@@ -257,6 +319,39 @@ var _lock = function(_this, mustLock, promiseFn) {
   return promiseFn(Promise.resolve());
 };
 
+var serialFsTask = function(array, each) {
+  return new Promise(function(resolve, reject) {
+    var index = 0;
+    function next(err) {
+      if (err) {
+        return reject(err);
+      }
+      if (index < array.length) {
+        var _next = function() {
+          index++;
+          if (index < array.length) {
+            each(array[index], function(e) {
+              _next(e);
+            });
+          }
+          else {
+            resolve();
+          }
+        };
+        each(array[index], function(e) {
+          _next(e);
+        });
+        _next = next;
+        index++;
+      }
+      else {
+        resolve();
+      }
+    }
+    next();
+  });
+};
+
 function AppendSerializer(options) {
   this.path = options.cacheDirPath;
   this.blockSize = options.blockSize || _blockSize;
@@ -269,6 +364,7 @@ function AppendSerializer(options) {
 }
 
 AppendSerializer.prototype.read = function(mustLock) {
+  var start = Date.now();
   var _this = this;
 
   function _read() {
@@ -339,6 +435,11 @@ AppendSerializer.prototype.read = function(mustLock) {
 };
 
 AppendSerializer.prototype.write = function(ops, mustLock) {
+  if (ops.length === 0) {
+    return Promise.resolve();
+  }
+
+  var steps = 0;
   var _this = this;
 
   var activeTable;
@@ -352,10 +453,9 @@ AppendSerializer.prototype.write = function(ops, mustLock) {
     })
     .then(function(_table) {
       activeTable = _table;
-    })
-    .then(function() {
       var _ops = ops.slice();
       function step() {
+        steps++;
         var op = _ops.shift();
         if (!op) {
           return;
@@ -363,22 +463,32 @@ AppendSerializer.prototype.write = function(ops, mustLock) {
 
         var content = op.value;
         if (content !== null) {
-          var blockCount = Math.ceil(content.length / activeTable.blockSize);
           var contentBuffer = new Buffer(content);
+          var blockCount = Math.ceil(
+            contentBuffer.length / activeTable.blockSize
+          );
           var nextIndex = activeTable.nextIndex;
           activeTable = putKey(activeTable, op.key, contentBuffer.length);
           var bufferIndex = 0;
 
-          function append() {
-            if (bufferIndex < contentBuffer.length) {
-              var blockSlice = contentBuffer.slice(bufferIndex, bufferIndex + activeTable.blockSize);
-              bufferIndex += activeTable.blockSize;
-              return _appendBlock(_this, activeTable, blockSlice, nextIndex++)
-              .then(append);
-            }
-          }
-          return append()
+          var bulk = Array.from(new Array(blockCount))
+          .map(function(_, i) {return i * activeTable.blockSize;});
+          return serialFsTask(bulk, function(bufferIndex, next) {
+            var blockSlice = contentBuffer.slice(bufferIndex, bufferIndex + activeTable.blockSize);
+            _appendBlock(_this, activeTable, blockSlice, nextIndex++, next);
+          })
           .then(step);
+
+          // function append() {
+          //   if (bufferIndex < contentBuffer.length) {
+          //     var blockSlice = contentBuffer.slice(bufferIndex, bufferIndex + activeTable.blockSize);
+          //     bufferIndex += activeTable.blockSize;
+          //     return _appendBlock(_this, activeTable, blockSlice, nextIndex++)
+          //     .then(append);
+          //   }
+          // }
+          // return append()
+          // .then(step);
         }
         else {
           activeTable = delKey(activeTable, op.key);


### PR DESCRIPTION
- Use native promises (official hard-source support is Node 6 and above so we can do that now)
- Group written blocks in AppendSerializer

Large projects hit the stack limit celling in the bluebird promise implementation causing a stack limit errors to be thrown and caught. Eventually it writes out to disk but the time spent here throwing and catching those errors is a lot.

While at it we can group the written blocks together to hopefully let a larger write to disk be more efficient and need less callback cycling.
