### PR TITLE
Cache read and write time related performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1283,13 +1283,6 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         });
       };
     });
-
-    params.normalModuleFactory.plugin('module', function(module) {
-      // module.isUsed = function(exportName) {
-      //   return exportName ? exportName : false;
-      // };
-      return module;
-    });
   });
 
   function preload(prefix, memoryCache) {

--- a/index.js
+++ b/index.js
@@ -1639,7 +1639,10 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
       if (item) {
         var frozen = cache.get(id);
         var newFrozen = freeze(archetype, frozen, item, extra);
-        if (frozen && newFrozen && newFrozen !== frozen || !frozen && newFrozen) {
+        if (
+          (frozen && newFrozen && newFrozen !== frozen) ||
+          (!frozen && newFrozen)
+        ) {
           cache.set(id, newFrozen);
           return newFrozen;
         }

--- a/index.js
+++ b/index.js
@@ -842,7 +842,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         walkDependencyBlock(cacheItem.dependencyBlock, function(cacheDependency) {
           if (
             cacheDependency &&
-            !cacheDependency.contextDependency &&
+            cacheDependency.type !== 'ContextDependency' &&
             typeof cacheDependency.request !== 'undefined'
           ) {
             var resolveId = cacheDependency._moduleResolveCacheId;

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var _rimraf = require('rimraf');
 var nodeObjectHash = require('node-object-hash');
 
 var envHash = require('./lib/env-hash');
+var promisify = require('./lib/util/promisify');
+var values = require('./lib/util/Object.values');
 
 var AMDRequireContextDependency = require('webpack/lib/dependencies/AMDRequireContextDependency');
 var CommonJsRequireContextDependency = require('webpack/lib/dependencies/CommonJsRequireContextDependency');
@@ -79,20 +81,6 @@ var hardSourceVersion = require('./package.json').version;
 
 function requestHash(request) {
   return crypto.createHash('sha1').update(request).digest().hexSlice();
-}
-
-function promisify(f, o) {
-  var ctx = o && o.context || null;
-  return function() {
-    var args = Array.from(arguments);
-    return new Promise(function(resolve, reject) {
-      args.push(function(err, value) {
-        if (err) {return reject(err);}
-        return resolve(value);
-      });
-      f.apply(ctx, args);
-    });
-  };
 }
 
 var mkdirp = promisify(_mkdirp, {context: _mkdirp});
@@ -737,7 +725,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         compiler.contextTimestamps = compiler.contextTimestamps || {};
         var contextTs = contextTimestamps = {};
         const contexts = contextStamps(dataCache.contextDependencies, stats);
-        return Promise.all(Object.values(contexts))
+        return Promise.all(values(contexts))
         .then(function() {
           for (var contextPath in contexts) {
             var context = contexts[contextPath];

--- a/index.js
+++ b/index.js
@@ -950,7 +950,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           return Promise.all(promise)
           .then(function() {
             if (!cacheItem || cacheItem.invalid) {
-              return Promise.reject();
+              throw new Error('invalid cacheItem');
             }
             checkedModules[result.request] = cacheItem;
             return cacheItem;
@@ -958,7 +958,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           .catch(function(e) {
             cacheItem.invalid = true;
             moduleCache[identifier] = null;
-            return Promise.reject();
+            throw new Error('invalid cacheItem');
           });
         }
         else {

--- a/index.js
+++ b/index.js
@@ -964,6 +964,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
             }
             else if (resolveItem && resolveItem.invalid) {
               cacheItem.invalid = true;
+              cacheItem.invalidReason = 'resolveItem';
               return;
             }
           }
@@ -1003,6 +1004,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
                   }
                   if (err) {
                     cacheItem.invalid = true;
+                    cacheItem.invalidReason = 'dependencyIdentifier';
                     return reject(err);
                   }
                   // IgnorePlugin and other plugins can call this callback
@@ -1220,6 +1222,7 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
         )) {
           // Bust this module, the keys exported or their order has changed.
           cacheItem.invalid = true;
+          cacheItem.invalidReason = 'used or usedExports';
           // moduleCache[identifier] = null;
 
           // Bust all dependents, they likely need to use new keys for this

--- a/index.js
+++ b/index.js
@@ -1346,20 +1346,38 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var preloadCacheByPrefix = {};
 
   compiler.plugin('compilation', function(compilation, params) {
-    var preloadMemoryCache = false;
-    params.normalModuleFactory.plugin('before-resolve', function(data, cb) {
-      if (preloadMemoryCache) {return cb(null, data);}
-      preloadMemoryCache = true;
-      if (compilation.cache) {
-        var prefix = cachePrefix(compilation);
-        if (prefix === null) {return cb(null, data);}
-        if (preloadCacheByPrefix[prefix]) {return cb(null, data);}
-        preloadCacheByPrefix[prefix] = true;
+    if (compilation.cache) {
+      var prefix = cachePrefix(compilation);
+      if (prefix === null) {return;}
+      if (preloadCacheByPrefix[prefix]) {return;}
+      preloadCacheByPrefix[prefix] = true;
+
+      var preloadMemoryCache = false;
+      params.normalModuleFactory.plugin('before-resolve', function(data, cb) {
+        if (preloadMemoryCache) {return cb(null, data);}
+        preloadMemoryCache = true;
 
         preload(prefix, compilation.cache);
-      }
-      return cb(null, data);
-    });
+
+        return cb(null, data);
+      });
+    }
+    else {
+      var preloadMemoryCache = false;
+      params.normalModuleFactory.plugin('before-resolve', function(data, cb) {
+        if (preloadMemoryCache) {return cb(null, data);}
+        preloadMemoryCache = true;
+        if (compilation.cache) {
+          var prefix = cachePrefix(compilation);
+          if (prefix === null) {return cb(null, data);}
+          if (preloadCacheByPrefix[prefix]) {return cb(null, data);}
+          preloadCacheByPrefix[prefix] = true;
+
+          preload(prefix, compilation.cache);
+        }
+        return cb(null, data);
+      });
+    }
   });
 
   compiler.plugin('make', function(compilation, cb) {

--- a/lib/env-hash.js
+++ b/lib/env-hash.js
@@ -9,19 +9,7 @@ var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
 
-function promisify(f, o) {
-  var ctx = o && o.context || null;
-  return function() {
-    var args = Array.from(arguments);
-    return new Promise(function(resolve, reject) {
-      args.push(function(err, value) {
-        if (err) {return reject(err);}
-        return resolve(value);
-      });
-      f.apply(ctx, args);
-    });
-  };
-}
+var promisify = require('./util/promisify');
 
 var readFile = promisify(fs.readFile);
 var readdir = promisify(fs.readdir);

--- a/lib/env-hash.js
+++ b/lib/env-hash.js
@@ -9,11 +9,23 @@ var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
 
-var Promise = require('bluebird');
+function promisify(f, o) {
+  var ctx = o && o.context || null;
+  return function() {
+    var args = Array.from(arguments);
+    return new Promise(function(resolve, reject) {
+      args.push(function(err, value) {
+        if (err) {return reject(err);}
+        return resolve(value);
+      });
+      f.apply(ctx, args);
+    });
+  };
+}
 
-var readFile = Promise.promisify(fs.readFile);
-var readdir = Promise.promisify(fs.readdir);
-var stat = Promise.promisify(fs.stat);
+var readFile = promisify(fs.readFile);
+var readdir = promisify(fs.readdir);
+var stat = promisify(fs.stat);
 
 function hashFile(file) {
   return readFile(file)

--- a/lib/hard-module.js
+++ b/lib/hard-module.js
@@ -69,6 +69,7 @@ function needRebuild(cacheItem, fileDependencies, contextDependencies, fileTimes
   }
   if (needsMd5Rebuild && fileMd5s && cachedMd5s) {
     cacheItem.invalid = true;
+    cacheItem.invalidReason = 'md5 mismatch';
   }
   return (
     cacheItem.invalid ||

--- a/lib/hard-source-append-serializer.js
+++ b/lib/hard-source-append-serializer.js
@@ -6,18 +6,8 @@ var _mkdirp = require('mkdirp');
 var _rimraf = require('rimraf');
 var writeJsonFile = require('write-json-file');
 
-function promisify(f) {
-  return function() {
-    var args = Array.from(arguments);
-    return new Promise(function(resolve, reject) {
-      args.push(function(err, value) {
-        if (err) {return reject(err);}
-        return resolve(value);
-      });
-      f.apply(null, args);
-    });
-  };
-}
+var values = require('./util/Object.values');
+var promisify = require('./util/promisify');
 
 var rimraf = promisify(_rimraf);
 var open = promisify(fs.open);
@@ -288,11 +278,6 @@ var _appendBlock = function(_this, _table, blockContent, index, next) {
   //   }
   //   return write(_this._fd, blockContent, 0, _table.blockSize);
   // });
-};
-
-var values = function(obj) {
-  return Object.keys(obj)
-  .map(key => obj[key]);
 };
 
 var _sizeNeeded = function(_this, _table) {

--- a/lib/hard-source-append-serializer.js
+++ b/lib/hard-source-append-serializer.js
@@ -282,7 +282,7 @@ var _appendBlock = function(_this, _table, blockContent, index, next) {
 
 var _sizeNeeded = function(_this, _table) {
   return values(_table.map).reduce(function(carry, value) {
-    return carry + value.size;
+    return carry + value.blocks * _table.blockSize;
   }, 0);
 };
 
@@ -293,7 +293,7 @@ var _sizeUsed = function(_this, _table) {
 var _compactSize = function(_this, _table) {
   return Math.max(
     _this.compactSizeThreshold,
-    _sizeNeeded(_this, _table) * this.compactMultiplierThreshold
+    _sizeNeeded(_this, _table) * _this.compactMultiplierThreshold
   );
 };
 
@@ -524,6 +524,10 @@ AppendSerializer.prototype.compact = function(mustLock) {
       });
     });
     return ops;
+  })
+  .then(function(ops) {
+    return rimraf(_this.path + '~')
+    .then(function() {return ops;});
   })
   .then(function(ops) {
     var copy = new AppendSerializer({

--- a/lib/hard-source-file-serializer.js
+++ b/lib/hard-source-file-serializer.js
@@ -3,19 +3,7 @@ var join = require('path').join;
 
 var _mkdirp = require('mkdirp');
 
-function promisify(f, o) {
-  var ctx = o && o.context || null;
-  return function() {
-    var args = Array.from(arguments);
-    return new Promise(function(resolve, reject) {
-      args.push(function(err, value) {
-        if (err) {return reject(err);}
-        return resolve(value);
-      });
-      f.apply(ctx, args);
-    });
-  };
-}
+var promisify = require('./util/promisify');
 
 var mkdirp = promisify(_mkdirp);
 var fsReadFile = promisify(fs.readFile, {context: fs});

--- a/lib/hard-source-file-serializer.js
+++ b/lib/hard-source-file-serializer.js
@@ -3,12 +3,24 @@ var join = require('path').join;
 
 var _mkdirp = require('mkdirp');
 
-var Promise = require('bluebird');
+function promisify(f, o) {
+  var ctx = o && o.context || null;
+  return function() {
+    var args = Array.from(arguments);
+    return new Promise(function(resolve, reject) {
+      args.push(function(err, value) {
+        if (err) {return reject(err);}
+        return resolve(value);
+      });
+      f.apply(ctx, args);
+    });
+  };
+}
 
-var mkdirp = Promise.promisify(_mkdirp);
-var fsReadFile = Promise.promisify(fs.readFile, {context: fs});
-var fsReaddir = Promise.promisify(fs.readdir, {context: fs});
-var fsWriteFile = Promise.promisify(fs.writeFile, {context: fs});
+var mkdirp = promisify(_mkdirp);
+var fsReadFile = promisify(fs.readFile, {context: fs});
+var fsReaddir = promisify(fs.readdir, {context: fs});
+var fsWriteFile = promisify(fs.writeFile, {context: fs});
 
 module.exports = FileSerializer;
 
@@ -28,7 +40,7 @@ FileSerializer.prototype.read = function() {
       return Promise.all([name, fsReadFile(join(cacheAssetDirPath, name))]);
     });
   })
-  .then(Promise.all)
+  .then(function(a) {return Promise.all(a);})
   .then(function(_assets) {
     for (var i = 0; i < _assets.length; i++) {
       assets[_assets[i][0]] = _assets[i][1];
@@ -46,5 +58,5 @@ FileSerializer.prototype.write = function(assetOps) {
       return fsWriteFile(assetPath, asset.value);
     });
   })
-  .then(Promise.all);
+  .then(function(a) {return Promise.all(a);});
 };

--- a/lib/hard-source-json-serializer.js
+++ b/lib/hard-source-json-serializer.js
@@ -1,18 +1,6 @@
 var fs = require('fs');
 
-function promisify(f, o) {
-  var ctx = o && o.context || null;
-  return function() {
-    var args = Array.from(arguments);
-    return new Promise(function(resolve, reject) {
-      args.push(function(err, value) {
-        if (err) {return reject(err);}
-        return resolve(value);
-      });
-      f.apply(ctx, args);
-    });
-  };
-}
+var promisify = require('./util/promisify');
 
 var fsReadFile = promisify(fs.readFile, {context: fs});
 var fsWriteFile = promisify(fs.writeFile, {context: fs});

--- a/lib/hard-source-json-serializer.js
+++ b/lib/hard-source-json-serializer.js
@@ -1,9 +1,21 @@
 var fs = require('fs');
 
-var Promise = require('bluebird');
+function promisify(f, o) {
+  var ctx = o && o.context || null;
+  return function() {
+    var args = Array.from(arguments);
+    return new Promise(function(resolve, reject) {
+      args.push(function(err, value) {
+        if (err) {return reject(err);}
+        return resolve(value);
+      });
+      f.apply(ctx, args);
+    });
+  };
+}
 
-var fsReadFile = Promise.promisify(fs.readFile, {context: fs});
-var fsWriteFile = Promise.promisify(fs.writeFile, {context: fs});
+var fsReadFile = promisify(fs.readFile, {context: fs});
+var fsWriteFile = promisify(fs.writeFile, {context: fs});
 
 module.exports = JsonSerializer;
 

--- a/lib/hard-source-leveldb-serializer.js
+++ b/lib/hard-source-leveldb-serializer.js
@@ -1,7 +1,20 @@
 var _level = require('level');
-var Promise = require('bluebird');
 
-var level = Promise.promisify(_level);
+function promisify(f, o) {
+  var ctx = o && o.context || null;
+  return function() {
+    var args = Array.from(arguments);
+    return new Promise(function(resolve, reject) {
+      args.push(function(err, value) {
+        if (err) {return reject(err);}
+        return resolve(value);
+      });
+      f.apply(ctx, args);
+    });
+  };
+}
+
+var level = promisify(_level);
 
 module.exports = LevelDbSerializer;
 
@@ -16,7 +29,7 @@ LevelDbSerializer.prototype.read = function() {
   return level(this.path)
   .then(function(db) {
     return new Promise(function(resolve, reject) {
-      var dbClose = Promise.promisify(db.close, {context: db});
+      var dbClose = promisify(db.close, {context: db});
       db.createReadStream()
       .on('data', function(data) {
         var value = data.value;
@@ -54,13 +67,13 @@ LevelDbSerializer.prototype.write = function(moduleOps) {
 
   return this.leveldbLock = this.leveldbLock
   .then(function() {
-    return Promise.promisify(level)(cachePath);
+    return level(cachePath);
   })
   .then(function(db) {
-    return Promise.promisify(db.batch, {context: db})(ops)
+    return promisify(db.batch, {context: db})(ops)
     .then(function() {return db;});
   })
   .then(function(db) {
-    return Promise.promisify(db.close, {context: db})();
+    return promisify(db.close, {context: db})();
   });
 };

--- a/lib/hard-source-leveldb-serializer.js
+++ b/lib/hard-source-leveldb-serializer.js
@@ -1,18 +1,6 @@
 var _level = require('level');
 
-function promisify(f, o) {
-  var ctx = o && o.context || null;
-  return function() {
-    var args = Array.from(arguments);
-    return new Promise(function(resolve, reject) {
-      args.push(function(err, value) {
-        if (err) {return reject(err);}
-        return resolve(value);
-      });
-      f.apply(ctx, args);
-    });
-  };
-}
+var promisify = require('./util/promisify');
 
 var level = promisify(_level);
 

--- a/lib/util/Object.values.js
+++ b/lib/util/Object.values.js
@@ -1,0 +1,4 @@
+module.exports = function Object_values(obj) {
+  return Object.keys(obj)
+  .map(key => obj[key]);
+};

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 
-var LoggerFactory = require('./logger-factory');
+var LoggerFactory = require('../logger-factory');
 
 exports.cachePrefix = cachePrefix;
 

--- a/lib/util/promisify.js
+++ b/lib/util/promisify.js
@@ -1,0 +1,12 @@
+module.exports = function promisify(f) {
+  return function promisify_wrap() {
+    var args = Array.from(arguments);
+    return new Promise(function promisify_resolver(resolve, reject) {
+      args.push(function promisify_callback(err, value) {
+        if (err) {return reject(err);}
+        return resolve(value);
+      });
+      f.apply(null, args);
+    });
+  };
+};

--- a/lib/util/promisify.js
+++ b/lib/util/promisify.js
@@ -1,4 +1,5 @@
-module.exports = function promisify(f) {
+module.exports = function promisify(f, o) {
+  var ctx = o && o.context || null;
   return function promisify_wrap() {
     var args = Array.from(arguments);
     return new Promise(function promisify_resolver(resolve, reject) {
@@ -6,7 +7,7 @@ module.exports = function promisify(f) {
         if (err) {return reject(err);}
         return resolve(value);
       });
-      f.apply(null, args);
+      f.apply(ctx, args);
     });
   };
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "webpack": "*"
   },
   "dependencies": {
-    "bluebird": "^3.0.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
     "node-object-hash": "^1.2.0",

--- a/tests/serializers.js
+++ b/tests/serializers.js
@@ -2,7 +2,20 @@ var fs = require('fs');
 var join = require('path').join;
 
 var expect = require('chai').expect;
-var Promise = require('bluebird');
+
+function promisify(f, o) {
+  var ctx = o && o.context || null;
+  return function() {
+    var args = Array.from(arguments);
+    return new Promise(function(resolve, reject) {
+      args.push(function(err, value) {
+        if (err) {return reject(err);}
+        return resolve(value);
+      });
+      f.apply(ctx, args);
+    });
+  };
+}
 
 var AppendSerializerPlugin = require('../lib/hard-source-append-serializer-plugin');
 
@@ -39,7 +52,7 @@ describe('hard source serializers - serializer abilities', function() {
 
     var cachePath = join(__dirname, 'fixtures/serializer-append-base-1dep-compact/tmp/cache');
 
-    var stat = Promise.promisify(fs.stat);
+    var stat = promisify(fs.stat);
     var oldSize;
 
     return Promise.resolve()


### PR DESCRIPTION
- Remove bluebird as a dependency
- Use watchpack produced timestamps if available
- Cache time file and context hash is built with hash
- Compare timestamp vs time when file has made instead of mtime of file
- Reorder the preload .cache check so rebuilds don't need to
- Remove promise use for synchronous work in hashing dependencies
- Remove promise use for validating resolutions
- Remove promise use for and building hashes for new modules

The promise work provides a benefit for iterative builds and watch rebuilds. The rest of the performance work benefits watch rebuilds.