### PR TITLE
Catch and log module freezing errors

### DIFF
--- a/lib/hard-compilation-plugin.js
+++ b/lib/hard-compilation-plugin.js
@@ -1,4 +1,5 @@
 var cachePrefix = require('./util').cachePrefix;
+var LoggerFactory = require('./logger-factory');
 
 function HardCompilationPlugin() {}
 
@@ -20,10 +21,35 @@ HardCompilationPlugin.prototype.apply = function(compiler) {
       }
       var identifier = identifierPrefix + module.identifier();
 
-      store('module', identifier, module, {
-        id: identifier,
-        compilation: compilation,
-      });
+      try {
+        store('module', identifier, module, {
+          id: identifier,
+          compilation: compilation,
+        });
+      }
+      catch (e) {
+        var loggerSerial = LoggerFactory.getLogger(compilation).from('serial');
+        var compilerName = compilation.compiler.name;
+        var compilerContext = compilation.compiler.context;
+        var moduleIdentifier = module.identifier();
+        var shortener = new (require('webpack/lib/RequestShortener'))(compilerContext);
+        var moduleReadable = module.readableIdentifier(shortener);
+
+        loggerSerial.error(
+          {
+            id: 'serialization--error-freezing-module',
+            identifierPrefix: identifierPrefix,
+            compilerName: compilerName,
+            moduleIdentifier: moduleIdentifier,
+            error: e,
+            errorMessage: e.message,
+            errorStack: e.stack,
+          },
+          'Unable to freeze module "' + moduleReadable +
+          (compilerName ? '" in compilation "' + compilerName : '') + '". An ' +
+          'error occured serializing it into a string: ' + e.message
+        );
+      }
     });
   });
 };


### PR DESCRIPTION
Add a try-catch aroudn module freezing to help debugging issues in
hard-source by providing module and compiler info on what failed.