### PR TITLE
Add error logging around freezing _inContextDependencyIdentifier

### DIFF
--- a/lib/hard-basic-dependency-plugin.js
+++ b/lib/hard-basic-dependency-plugin.js
@@ -7,6 +7,7 @@ var cachePrefix = require('./util').cachePrefix;
 var HardContextDependency = require('./dependencies').HardContextDependency;
 var HardModuleDependency = require('./dependencies').HardModuleDependency;
 var HardNullDependency = require('./dependencies').HardNullDependency;
+var LoggerFactory = require('./logger-factory');
 
 function flattenPrototype(obj) {
   if (typeof obj === 'string') {
@@ -94,9 +95,44 @@ HardBasicDependencyPlugin.prototype.apply = function(compiler) {
       // The identifier this dependency should resolve to.
       var _resolvedModuleIdentifier =
         dependency.module && dependency.__hardSource_resolvedModuleIdentifier;
-      // An identifier to dereference a dependency under a module to some per
-      // dependency value
-      var _inContextDependencyIdentifier = module && JSON.stringify([module.context, frozen]);
+      try {
+        // An identifier to dereference a dependency under a module to some per
+        // dependency value
+        var _inContextDependencyIdentifier = module &&
+          JSON.stringify([module.context, frozen.importDependency || frozen]);
+      }
+      catch (e) {
+        var loggerSerial = LoggerFactory.getLogger(compilation).from('serial');
+        var compilerName = compilation.compiler.name;
+        var compilerContext = compilation.compiler.context;
+        var depModuleIdentifier = dependency.module &&
+          dependency.module.identifier();
+        var moduleIdentifier = module.identifier();
+        var shortener = new (require('webpack/lib/RequestShortener'))(
+          compilerContext
+        );
+        var depModuleReadable = dependency.module &&
+          dependency.module.readableIdentifier(shortener);
+        var moduleReadable = module.readableIdentifier(shortener);
+
+        loggerSerial.error(
+          {
+            id: 'serialization--error-freezing-dependency',
+            identifierPrefix: identifierPrefix,
+            compilerName: compilerName,
+            dependencyModuleIdentifier: depModuleIdentifier,
+            moduleIdentifier: moduleIdentifier,
+            error: e,
+            errorMessage: e.message,
+            errorStack: e.stack,
+          },
+          'Unable to freeze ' + frozen.type + ' dependency to "' +
+          depModuleReadable + '" in "' + moduleReadable +
+          (compilerName ? '" in compilation "' + compilerName : '') + '". An ' +
+          'error occured serializing it into a string: ' + e.message
+        );
+        throw e;
+      }
       // An identifier from the dependency to the cached resolution information
       // for building a module.
       var _moduleResolveCacheId = module && frozen.request && JSON.stringify([identifierPrefix, module.context, frozen.request]);


### PR DESCRIPTION
Related to #205

- stringify frozen.importDependency || frozen

Freeze the dependency or referenced dependency that points to a module.
We don't need all of the dependencies details for harmony dependencies
to know if the factory returns the expect module.