### PR TITLE
Fix testing dependency on cache context modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1053,8 +1053,12 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
           })
           .catch(function(e) {
             cacheItem.invalid = true;
+            cacheItem.invalidReason = 'error while validating dependencies';
             moduleCache[identifier] = null;
-            throw new Error('invalid cacheItem');
+            throw new Error(
+              'invalid cacheItem: ' + e.message + '\n' +
+              (e.stack && e.stack.split('\n')[1])
+            );
           });
         }
         else {

--- a/lib/hard-basic-dependency-plugin.js
+++ b/lib/hard-basic-dependency-plugin.js
@@ -59,6 +59,15 @@ HardBasicDependencyPlugin.prototype.apply = function(compiler) {
       frozen.loc = flattenPrototype(dependency.loc);
     }
 
+    if (frozen && dependency.getWarnings) {
+      var warnings = dependency.getWarnings();
+      if (warnings && warnings.length) {
+        frozen.warnings = warnings.map(function(warning) {
+          return warning.stack.split('\n    at Compiler.<anonymous>')[0];
+        });
+      }
+    }
+
     return frozen;
   });
 
@@ -171,6 +180,22 @@ HardBasicDependencyPlugin.prototype.apply = function(compiler) {
   compiler.plugin('--hard-source-after-thaw-dependency', function(dependency, frozen, extra) {
     if (dependency && frozen.loc) {
       dependency.loc = frozen.loc;
+    }
+
+    if (dependency && frozen.warnings && dependency.getWarnings) {
+      var frozenWarnings = frozen.warnings;
+      var _getWarnings = dependency.getWarnings;
+      dependency.getWarnings = function() {
+        var warnings = _getWarnings.call(this);
+        if (warnings && warnings.length) {
+          return warnings.map(function(warning, i) {
+            var stack = warning.stack.split('\n    at Compilation.reportDependencyErrorsAndWarnings')[1];
+            warning.stack = frozenWarnings[i] + '\n    at Compilation.reportDependencyErrorsAndWarnings' + stack;
+            return warning;
+          });
+        }
+        return warnings;
+      };
     }
 
     return dependency;

--- a/lib/hard-context-module-factory.js
+++ b/lib/hard-context-module-factory.js
@@ -11,9 +11,20 @@ function HardContextModuleFactory(options) {
   this.fileTimestamps = options.fileTimestamps;
   this.fileMd5s = options.fileMd5s;
   this.cachedMd5s = options.cachedMd5s;
+
+  if (this.factory.create.length === 2) {
+    this.create = function(data, cb) {
+      return this._create(data, cb);
+    };
+  }
+  else {
+    this.create = function(context, dependency, cb) {
+      return this._create(context, dependency, cb);
+    };
+  }
 }
 
-HardContextModuleFactory.prototype.create = function(context, dependency, callback) {
+HardContextModuleFactory.prototype._create = function(context, dependency, callback) {
   var compilation = this.compilation;
   var factory = this.factory;
   var resolveCache = this.resolveCache;
@@ -86,7 +97,10 @@ HardContextModuleFactory.prototype.create = function(context, dependency, callba
     };
 
     module.needRebuild = function(fileTimestamps, contextTimestamps) {
-      return HardContextModule.needRebuild({context: this.context, builtTime: this.builtTime}, fileTimestamps, contextTimestamps, fileMd5s, cachedMd5s);
+      return HardContextModule.needRebuild({
+        context: this.context,
+        builtTime: this.builtTime
+      }, fileTimestamps, contextTimestamps, fileMd5s, cachedMd5s);
     };
 
     callback(error, module);

--- a/lib/logger-factory.js
+++ b/lib/logger-factory.js
@@ -86,7 +86,7 @@ Logger.prototype.write = function(value) {
     ).call(this.compiler, 'hard-source-log', value);
   }
   else {
-    console[value.level].call(
+    (console[value.level] || console.error).call(
       console,
       '[' + DEFAULT_LOGGER_PREFIX + LOGGER_SEPARATOR + value.from + ']',
       value.message

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -70,7 +70,7 @@ describe('basic webpack use - compiles identically', function() {
 describe('basic webpack use - compiles hard modules', function() {
 
   itCompilesHardModules('base-1dep', ['./fib.js', './index.js']);
-  itCompilesHardModules('base-context', ['./a nonrecursive \\d']);
+  itCompilesHardModules('base-context', ['./a nonrecursive \\d', './a/index.js']);
   itCompilesHardModules('base-deep-context', ['./a \\d']);
   itCompilesHardModules('base-code-split', ['./fib.js', './index.js']);
   itCompilesHardModules('base-query-request', ['./fib.js?argument']);

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -212,13 +212,20 @@ exports.compileTwiceEqual = function(fixturePath, compileOptions) {
 };
 
 exports.itCompilesTwice = function(fixturePath, compileOptions) {
-  before(function() {
-    return exports.clean(fixturePath);
-  });
+  // before(function() {
+  //   return exports.clean(fixturePath);
+  // });
 
-  it('builds identical ' + fixturePath + ' fixture', function() {
+  var exportSuffix = '';
+  if (compileOptions && compileOptions.exportStats) {
+    exportSuffix = ' [exportStats]';
+  }
+  it('builds identical ' + fixturePath + ' fixture' + exportSuffix, function() {
     this.timeout(10000);
-    return exports.compileTwiceEqual(fixturePath, compileOptions);
+    return exports.clean(fixturePath)
+    .then(function() {
+      return exports.compileTwiceEqual(fixturePath, compileOptions);
+    });
   });
 };
 


### PR DESCRIPTION
Related #182

ContextModules may or may not be cached but when another module depended on a context module, checking that the dependency to that context returned an equivalent module would error in webpack >2 because of a mismatch in HardContextModuleFactory.create argument count.