### PR TITLE
Fix sourceMap.sourcesContent = undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tests/fixtures/*/tmp
+node_modules

--- a/lib/hard-source-map-plugin.js
+++ b/lib/hard-source-map-plugin.js
@@ -18,6 +18,7 @@ HardSourceMapPlugin.prototype.apply = function(compiler) {
     var map = devtoolOptions && source.map(devtoolOptions);
     if (
       map &&
+      map.sourcesContent &&
       (
         source.constructor.name === 'CachedSource' &&
         source._source.constructor.name === 'ReplaceSource' &&
@@ -31,10 +32,10 @@ HardSourceMapPlugin.prototype.apply = function(compiler) {
         source._source && source._source._value ||
         source._source && source._source._source &&
           source._source._source._value;
+
       if (map.sourcesContent[0] === _value) {
         removedQuality = 'transformed';
-      }
-      else if (map.sourcesContent[0] === originalSource) {
+      } else if (map.sourcesContent[0] === originalSource) {
         removedQuality = 'original';
       }
       // else if (originalSource) {


### PR DESCRIPTION
Minor fix regarding when sourceMap.sourcesContent is `undefined`

https://github.com/webpack/webpack/blob/master/lib/SourceMapDevToolPlugin.js#L163