### PR TITLE
Help ensure ContextModuleFactory can be integrated

### DIFF
--- a/index.js
+++ b/index.js
@@ -829,9 +829,10 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   });
 
   compiler.plugin('after-plugins', function() {
-    compiler.plugin('compilation', function(compilation) {
+    compiler.plugin('compilation', function(compilation, params) {
       var factories = compilation.dependencyFactories;
-      var contextFactory = factories.get(RequireContextDependency);
+      var contextFactory = factories.get(RequireContextDependency) ||
+        params.contextModuleFactory;
 
       var hardContextFactory = new HardContextModuleFactory({
         compilation: compilation,


### PR DESCRIPTION
In case ContextModuleFactory has not been connected to its traditional
dependencies before HardSource integrates with webpack, use the factory
on the params argument passed to the compilation hook.