### PR TITLE
Check if cacheItem.sourceMap.map exists

### DIFF
--- a/lib/hard-source.js
+++ b/lib/hard-source.js
@@ -24,7 +24,7 @@ HardSource.prototype = Object.create(RawSource.prototype);
 HardSource.prototype.constructor = HardSource;
 
 function chooseMap(options, cacheItem) {
-  if (options && Object.keys(options).length) {
+  if (cacheItem.sourceMap.map && options && Object.keys(options).length) {
     if (
       cacheItem.sourceMap.map.sourcesContent &&
       cacheItem.sourceMap.map.sourcesContent.length === 0


### PR DESCRIPTION
In our test setup we use the webpack.SourceMapDevToolPlugin() and this seems to produce sourceMap items without a 'map' property. The code in lib/hard-source.js#chooseMap assumes that the property exists when 'options' are passed to chooseMap(), but in our case this results in a runtime error. I've added a simple reference check for the 'map' property, but none for the 'baseMap' property since I assume it is always present?
  
  