### PR TITLE
Fix webpack 3 and 4 performance regressions

### DIFF
--- a/lib/hard-normal-module-plugin.js
+++ b/lib/hard-normal-module-plugin.js
@@ -96,6 +96,7 @@ const serialNormalModule4 = serial.serial('NormalModule', {
     buildMeta: serial.identity,
     buildInfo: serial.created({
       assets: serial.moduleAssets,
+      cacheable: serial.identity,
       fileDependencies: serial.pathSet,
       contextDependencies: serial.pathSet,
       harmonyModule: serial.identity,
@@ -233,16 +234,24 @@ const serialNormalModule3 = serial.serial('NormalModule', {
   build: serial.assigned({
     built: serial.identity,
     buildTimestamp: serial.identity,
+    cacheable: serial.identity,
     meta: serial.identity,
     assets: serial.moduleAssets,
-    fileDependencies: serial.pathSet,
-    contextDependencies: serial.pathSet,
+    fileDependencies: serial.pathArray,
+    contextDependencies: serial.pathArray,
     harmonyModule: serial.identity,
     strict: serial.identity,
     exportsArgument: serial.identity,
     warnings: serial.moduleWarning,
     errors: serial.moduleError,
     _source: serial.source,
+  }),
+
+  hash: ({
+    freeze(arg, module, extra, methods) {
+      return module.getHashDigest(extra.compilation.dependencyTemplates);
+    },
+    thaw(arg) {return arg;},
   }),
 
   dependencyBlock: serial.dependencyBlock,
@@ -286,7 +295,7 @@ const needRebuild3 = function() {
       return true;
     }
   }
-  for (const dir of this.fileDependencies) {
+  for (const dir of this.contextDependencies) {
     if (!cachedHashes[dir] || fileHashes[dir] !== cachedHashes[dir]) {
       this.cacheItem.invalid = true;
       this.cacheItem.invalidReason = 'md5 mismatch';
@@ -366,9 +375,10 @@ HardNormalModulePlugin.prototype.apply = function(compiler) {
       module instanceof NormalModule &&
       (
         !frozen ||
-        schema === 4 &&
-        module.getHashDigest(extra.compilation.dependencyTemplates) !== frozen.source._cachedSourceHash ||
-        module.getHashDigest(extra.compilation.dependencyTemplates) !== frozen.source._cachedSource.hash
+        schema >= 4 &&
+        module.hash !== frozen.build.hash ||
+        schema < 4 &&
+        module.getHashDigest(extra.compilation.dependencyTemplates) !== frozen.hash
       )
     ) {
       var compilation = extra.compilation;


### PR DESCRIPTION
Either were unable to used already built modules because they had not
serialized their cacheable property or they were incidentally storing
modules to disk every build.