### PR TITLE
Add append table write retries and rimraf timeouts

### DIFF
--- a/lib/hard-source-append-serializer.js
+++ b/lib/hard-source-append-serializer.js
@@ -98,6 +98,25 @@ var _defaultTable = function(_this) {
   });
 };
 
+var timeout100 = function() {
+  return new Promise(function(resolve) {
+    return setTimeout(resolve, 100);
+  });
+};
+
+var _retry = function(fn, n) {
+  n = n || 5;
+  var _retryFn = function(value) {
+    if (n) {
+      n--;
+      return fn(value)
+      .catch(_retryFn);
+    }
+    return fn(value);
+  };
+  return _retryFn;
+};
+
 var _readTable = function(_this) {
   return readFile(_tablepath(_this), 'utf8')
   .catch(function(e) {
@@ -137,7 +156,8 @@ var _openLog = function(_this, mode, _table, index) {
         return stat(_logFilepath(_this, _table, index))
         .then(function(_stat) {
           if (_stat.size > 0) {
-            return unlink(_logFilepath(_this, _table, index));
+            return unlink(_logFilepath(_this, _table, index))
+            .then(timeout100);
           }
         })
         .catch(function() {});
@@ -363,9 +383,9 @@ AppendSerializer.prototype.read = function(mustLock) {
   function _read() {
     var activeTable;
     return Promise.resolve()
-    .then(function() {
+    .then(_retry(function() {
       return _readTable(_this);
-    })
+    }))
     .then(function(_table) {
       activeTable = _table;
     })
@@ -470,12 +490,12 @@ AppendSerializer.prototype.write = function(ops, mustLock) {
   var contentLength;
   function _write() {
     return Promise.resolve()
-    .then(function() {
+    .then(_retry(function() {
       return mkdirp(_this.path);
-    })
-    .then(function() {
+    }))
+    .then(_retry(function() {
       return _readTable(_this);
-    })
+    }))
     .then(function(_table) {
       activeTable = modTable(_table);
       var _ops = ops.slice();
@@ -548,10 +568,10 @@ AppendSerializer.prototype.write = function(ops, mustLock) {
     .then(function() {
       return _closeLog(_this);
     })
-    .then(function() {
+    .then(_retry(function() {
       activeTable = table(activeTable);
       return _writeTable(_this, activeTable);
-    });
+    }));
   }
 
   return _lock(_this, mustLock, function(promise) {
@@ -589,6 +609,7 @@ AppendSerializer.prototype.compact = function(mustLock) {
   })
   .then(function(ops) {
     return rimraf(_this.path + '~')
+    .then(timeout100)
     .then(function() {return ops;});
   })
   .then(function(ops) {
@@ -609,6 +630,7 @@ AppendSerializer.prototype.compact = function(mustLock) {
       .then(function() {
         return rimraf(_this.path);
       })
+      .then(timeout100)
       .then(function() {
         return rename(copy.path, _this.path);
       });


### PR DESCRIPTION
Fix #260

- Retry table writing in case the atomic writing errors on Windows
- Delay a little after all unlink and rimraf operations to help protect
  against Windows file errors