### PR TITLE
Fixed bug #265. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## 0.6.X Patches
 
+- `0.6.0-alpha.9` Additional protection against source path being locked when copied
 - `0.6.0-alpha.8` Protect append serializer from rename and unlink errors on Windows
 - `0.6.0-alpha.7` Move babel dependencies to development
 - `0.6.0-alpha.6` Fix unneeded rebuilding performance regressions

--- a/lib/hard-source-append-serializer.js
+++ b/lib/hard-source-append-serializer.js
@@ -24,7 +24,7 @@ var mkdirp = promisify(_mkdirp);
 module.exports = AppendSerializer;
 
 var APPEND_VERSION = 1;
- 
+
 var _blockSize = 4 * 1024;
 var _logSize = 2 * 1024 * 1024;
 var _minCompactSize = 512 * 1024;
@@ -631,9 +631,9 @@ AppendSerializer.prototype.compact = function(mustLock) {
         return rimraf(_this.path);
       })
       .then(timeout100)
-      .then(function() {
+      .then(_retry(function() {
         return rename(copy.path, _this.path);
-      });
+      }, 10));
     });
   });
 };


### PR DESCRIPTION
Additional fix for the previous bug. When module folder is supposed to be copied, it's locked by Windows. I now make sure an error is not thrown and retry the step 10 times. 
During testing it took as much as 6-7 tries.

Fixes bug #265 

I hope I didn't overstep any boundaries by adding to the change log and bumping version in package.json. Feel free to remove those if you want to.

Edit: I noticed you want to keep you release commits clean. Reverted bump.