### PR TITLE
perf(cache size): Do not freeze activeExports

### DIFF
--- a/lib/hard-basic-dependency-plugin.js
+++ b/lib/hard-basic-dependency-plugin.js
@@ -223,10 +223,14 @@ const freezeArgument = {
     // This will be in extra, generated or found during the process of thawing.
   },
   activeExports(arg, dependency, extra, methods) {
-    return Array.from(arg);
+    return null;
   },
   otherStarExports(arg, dependency, extra, methods) {
-    // This will be in extra, generated during the process of thawing.
+    if (arg) {
+      // This will be in extra, generated during the process of thawing.
+      return 'star';
+    }
+    return null;
   },
   options(arg, dependency, extra, methods) {
     if (arg.regExp) {
@@ -273,10 +277,17 @@ const thawArgument = {
     return extra.module;
   },
   activeExports(arg, frozen, extra, methods) {
-    return new Set(arg);
+    extra.state.activeExports = extra.state.activeExports || new Set();
+    if (frozen.name) {
+      extra.state.activeExports.add(frozen.name);
+    }
+    return extra.state.activeExports;
   },
   otherStarExports(arg, frozen, extra, methods) {
-    return extra.state.otherStarExports || [];
+    if (arg === 'star') {
+      return extra.state.otherStarExports || [];
+    }
+    return null;
   },
   options(arg, frozen, extra, methods) {
     if (arg.regExp) {
@@ -483,10 +494,10 @@ HardBasicDependencyPlugin.prototype.apply = function(compiler) {
         state.imports[ref] = _thawed;
       }
       else if (frozen.type === 'HarmonyExportImportedSpecifierDependency') {
-        // console.log(frozen);
-        // console.log(_thawed);
-        extra.state.otherStarExports = (extra.state.otherStarExports || [])
-        .concat(_thawed);
+        if (_thawed.otherStarExports) {
+          extra.state.otherStarExports = (extra.state.otherStarExports || [])
+          .concat(_thawed);
+        }
       }
       return _thawed;
     }


### PR DESCRIPTION
- Do not freeze activeExports set for HarmonyExportImportedSpecifierDependency.
  It can be recreated deterministically in the next build.
- Do not thaw otherStarExports for all HarmonyExportImportedSpecifierDependency
  instances.