### PR TITLE
Add safety nets to early dependency freezing in Modules

### DIFF
--- a/lib/hard-compilation-plugin.js
+++ b/lib/hard-compilation-plugin.js
@@ -1,6 +1,6 @@
-var cachePrefix = require('./util').cachePrefix;
-var LoggerFactory = require('./logger-factory');
-var pluginCompat = require('./util/plugin-compat');
+const cachePrefix = require('./util').cachePrefix;
+const logMessages = require('./util/log-messages');
+const pluginCompat = require('./util/plugin-compat');
 
 function HardCompilationPlugin() {}
 
@@ -29,27 +29,7 @@ HardCompilationPlugin.prototype.apply = function(compiler) {
         });
       }
       catch (e) {
-        var loggerSerial = LoggerFactory.getLogger(compilation).from('serial');
-        var compilerName = compilation.compiler.name;
-        var compilerContext = compilation.compiler.options.context;
-        var moduleIdentifier = module.identifier();
-        var shortener = new (require('webpack/lib/RequestShortener'))(compilerContext);
-        var moduleReadable = module.readableIdentifier(shortener);
-
-        loggerSerial.error(
-          {
-            id: 'serialization--error-freezing-module',
-            identifierPrefix: identifierPrefix,
-            compilerName: compilerName,
-            moduleIdentifier: moduleIdentifier,
-            error: e,
-            errorMessage: e.message,
-            errorStack: e.stack,
-          },
-          'Unable to freeze module "' + moduleReadable +
-          (compilerName ? '" in compilation "' + compilerName : '') + '". An ' +
-          'error occured serializing it into a string: ' + e.message
-        );
+        logMessages.moduleFreezeError(compilation, module, e);
       }
     });
   });

--- a/lib/hard-context-module-plugin.js
+++ b/lib/hard-context-module-plugin.js
@@ -1,8 +1,8 @@
 const ContextModule = require('webpack/lib/ContextModule');
 
-const HardContextModule = require('./hard-context-module');
-const pluginCompat = require('./util/plugin-compat');
+const logMessages = require('./util/log-messages');
 
+const pluginCompat = require('./util/plugin-compat');
 const relateContext = require('./util/relate-context');
 const serial = require('./util/serial');
 
@@ -309,14 +309,19 @@ class HardModuleContextPlugin {
       // mapThaw = _methods.mapThaw;
     });
 
-    pluginCompat.tap(compiler, 'compilation', 'HardNormalModulePlugin', compilation => {
-      pluginCompat.tap(compilation, 'succeedModule', 'HardNormalModulePlugin', module => {
+    pluginCompat.tap(compiler, 'compilation', 'HardContextModulePlugin', compilation => {
+      pluginCompat.tap(compilation, 'succeedModule', 'HardContextModulePlugin', module => {
         if (module instanceof ContextModule) {
-          module._dependencyBlock = freeze('DependencyBlock', null, module, {
-            module: module,
-            parent: module,
-            compilation: compilation,
-          });
+          try {
+            module._dependencyBlock = freeze('DependencyBlock', null, module, {
+              module: module,
+              parent: module,
+              compilation: compilation,
+            });
+          }
+          catch (e) {
+            logMessages.moduleFreezeError(compilation, module, e);
+          }
         }
       });
     });

--- a/lib/hard-normal-module-plugin.js
+++ b/lib/hard-normal-module-plugin.js
@@ -1,15 +1,15 @@
-var NormalModule = require('webpack/lib/NormalModule');
-var Module = require('webpack/lib/Module');
+const NormalModule = require('webpack/lib/NormalModule');
+const Module = require('webpack/lib/Module');
 
-var {
+const logMessages = require('./util/log-messages');
+const {
   relateNormalPath,
   relateNormalRequest,
   relateNormalPathSet,
-  relateNormalLoaders,
-  relateNormalPathSet
+  relateNormalLoaders
 } = require('./util/relate-context');
-var pluginCompat = require('./util/plugin-compat');
-var serial = require('./util/serial');
+const pluginCompat = require('./util/plugin-compat');
+const serial = require('./util/serial');
 
 const serialNormalModule4 = serial.serial('NormalModule', {
   constructor: serial.constructed(NormalModule, {
@@ -343,11 +343,16 @@ HardNormalModulePlugin.prototype.apply = function(compiler) {
   pluginCompat.tap(compiler, 'compilation', 'HardNormalModulePlugin', compilation => {
     pluginCompat.tap(compilation, 'succeedModule', 'HardNormalModulePlugin', module => {
       if (module instanceof NormalModule) {
-        module._dependencyBlock = freeze('DependencyBlock', null, module, {
-          module: module,
-          parent: module,
-          compilation: compilation,
-        });
+        try {
+          module._dependencyBlock = freeze('DependencyBlock', null, module, {
+            module: module,
+            parent: module,
+            compilation: compilation,
+          });
+        }
+        catch (e) {
+          logMessages.moduleFreezeError(compilation, module, e);
+        }
       }
     });
   });

--- a/lib/util/log-messages.js
+++ b/lib/util/log-messages.js
@@ -1,0 +1,27 @@
+const cachePrefix = require('.').cachePrefix;
+const LoggerFactory = require('../logger-factory');
+
+exports.moduleFreezeError = (compilation, module, e) => {
+  const loggerSerial = LoggerFactory.getLogger(compilation).from('serial');
+  const compilerName = compilation.compiler.name;
+  const compilerContext = compilation.compiler.options.context;
+  const identifierPrefix = cachePrefix(compilation);
+  const moduleIdentifier = module.identifier();
+  const shortener = new (require('webpack/lib/RequestShortener'))(compilerContext);
+  const moduleReadable = module.readableIdentifier(shortener);
+
+  loggerSerial.error(
+    {
+      id: 'serialization--error-freezing-module',
+      identifierPrefix: identifierPrefix,
+      compilerName: compilerName,
+      moduleIdentifier: moduleIdentifier,
+      error: e,
+      errorMessage: e.message,
+      errorStack: e.stack,
+    },
+    'Unable to freeze module "' + moduleReadable +
+    (compilerName ? '" in compilation "' + compilerName : '') + '". An ' +
+    'error occured serializing it into a string: ' + e.message
+  );
+};


### PR DESCRIPTION
To help support webpack 4's side effects feature, dependencies need to be
serialized early to not get modified. If these dependencies cause an error
while being frozen log a message and let webpack continue without being able to
freeze those dependencies.