### PR TITLE
fix: Use more generalized cycle detection on dependency block member

### DIFF
--- a/lib/hard-basic-dependency-plugin.js
+++ b/lib/hard-basic-dependency-plugin.js
@@ -208,10 +208,8 @@ const freezeArgument = {
     return relateContext.relateAbsoluteRequest(extra.module.context, arg);
   },
   block(arg, dependency, extra, methods) {
-    if (
-      dependency.constructor.name === 'AMDRequireDependency' ||
-      dependency.constructor.name === 'ImportDependency'
-    ) {
+    // Dependency nested in a parent. Freezing the block is a loop.
+    if (arg.dependencies.indexOf(dependency) !== -1) {
       return;
     }
     return methods.freeze('DependencyBlock', null, arg, extra);
@@ -262,10 +260,9 @@ const thawArgument = {
   //   return relateContext.contextNormalRequest(extra.compilation.compiler, arg);
   // },
   block(arg, frozen, extra, methods) {
-    if (
-      frozen.type === 'AMDRequireDependency' ||
-      frozen.type === 'ImportDependency'
-    ) {
+    // Not having a block, means it needs to create a cycle and refer to its
+    // parent.
+    if (!arg) {
       return extra.parent;
     }
     return methods.thaw('DependencyBlock', null, arg, extra);

--- a/tests/base-webpack-1.js
+++ b/tests/base-webpack-1.js
@@ -24,6 +24,8 @@ describe('basic webpack use - compiles identically', function() {
   itCompilesTwice('base-code-split', {exportStats: true});
   itCompilesTwice('base-code-split-devtool-source-map');
   itCompilesTwice('base-code-split-devtool-source-map', {exportStats: true});
+  itCompilesTwice('base-code-split-ensure');
+  itCompilesTwice('base-code-split-ensure', {exportStats: true});
   itCompilesTwice('base-code-split-nest');
   itCompilesTwice('base-code-split-nest', {exportStats: true});
   itCompilesTwice('base-code-split-nest-devtool-source-map');

--- a/tests/fixtures/base-code-split-ensure/fib.js
+++ b/tests/fixtures/base-code-split-ensure/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-code-split-ensure/index.js
+++ b/tests/fixtures/base-code-split-ensure/index.js
@@ -1,0 +1,5 @@
+require.ensure([], function() {
+  var fib = require('./fib');
+
+  console.log(fib(3));
+});

--- a/tests/fixtures/base-code-split-ensure/webpack.config.js
+++ b/tests/fixtures/base-code-split-ensure/webpack.config.js
@@ -1,0 +1,15 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+    }),
+  ],
+};


### PR DESCRIPTION
Fix #283

Break up dependency -> block -> dependency cycles with a generic test
instead of testing if the dependency is one of a set of specific types.