### PR TITLE
Bump babel-loader version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "ISC",
   "devDependencies": {
     "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
+    "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",
     "chai": "^3.5.0",
     "css-loader": "^0.27.0",


### PR DESCRIPTION
Set babel-loader dev dependency to version that recognizes webpack 4 as a valid peer.

This removes an npm peer dependency mismatch warning.