### PR TITLE
Add MiniCssExtractPlugin support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1646,6 +1646,10 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   var HardModuleAssetsPlugin = require('./lib/hard-module-assets-plugin');
   var HardModuleErrorsPlugin = require('./lib/hard-module-errors-plugin');
   var HardModuleExtractTextPlugin = require('./lib/hard-module-extract-text-plugin');
+  var HardModuleMiniCssExtractPlugin;
+  if (webpackFeatures.generator) {
+    HardModuleMiniCssExtractPlugin = require('./lib/hard-module-mini-css-extract-plugin');
+  }
   var HardDependencyBlockPlugin = require('./lib/hard-dependency-block-plugin');
   var HardBasicDependencyPlugin = require('./lib/hard-basic-dependency-plugin');
   var HardHarmonyDependencyPlugin;
@@ -1674,6 +1678,10 @@ HardSourceWebpackPlugin.prototype.apply = function(compiler) {
   new HardModuleAssetsPlugin().apply(compiler);
   new HardModuleErrorsPlugin().apply(compiler);
   new HardModuleExtractTextPlugin().apply(compiler);
+
+  if (HardModuleMiniCssExtractPlugin) {
+    new HardModuleMiniCssExtractPlugin().apply(compiler);
+  }
 
   new HardDependencyBlockPlugin({
     schema: schemasVersion,

--- a/lib/hard-basic-dependency-plugin.js
+++ b/lib/hard-basic-dependency-plugin.js
@@ -400,6 +400,28 @@ HardBasicDependencyPlugin.prototype.apply = function(compiler) {
           }
         }
       }
+      for (let i = 0; i < schemas.length; i++) {
+        if (!schemas[i].Dependency) {
+          if (this.options.schema < 4) {}
+          else {
+            if (schemas[i][0] === 'JsonExportsDependency') {
+              try {
+                schemas[i].Dependency = require('webpack/lib/dependencies/JsonExportsDependency');
+              } catch (_) {}
+            }
+            else if (schemas[i][0] === 'DelegatedExportsDependency') {
+              try {
+                schemas[i].Dependency = require('webpack/lib/dependencies/DelegatedExportsDependency');
+              } catch (_) {}
+            }
+            else if (schemas[i][0] === 'DelegatedSourceDependency') {
+              try {
+                schemas[i].Dependency = require('webpack/lib/dependencies/DelegatedSourceDependency');
+              } catch (_) {}
+            }
+          }
+        }
+      }
     });
   });
 

--- a/lib/hard-dependency-block-plugin.js
+++ b/lib/hard-dependency-block-plugin.js
@@ -94,6 +94,20 @@ function thawDependencyBlock(frozen, extra, methods) {
   }
 }
 
+function assertFrozen(frozen, original, typeName, freeze) {
+  if (frozen.length !== original.length) {
+    const didNotFreeze = original.filter(item => !freeze(item));
+    if (didNotFreeze.length > 0) {
+      throw new Error('Unfrozen ' + typeName + ': ' +
+        didNotFreeze
+        .map(item => item.constructor.name)
+        .filter((name, i, names) => !names.slice(0, i).includes(name))
+        .join(', ')
+      );
+    }
+  }
+}
+
 function HardDependencyBlockPlugin(options) {
   this.options = options;
 }
@@ -110,12 +124,12 @@ HardDependencyBlockPlugin.prototype.apply = function(compiler) {
     methods = _methods;
   });
 
-  var mapFreeze, mapThaw;
+  var freeze, mapFreeze, mapThaw;
 
   pluginCompat.tap(compiler, '_hardSourceMethods', 'HardDependencyBlockPlugin', function(methods) {
     // store = methods.store;
     // fetch = methods.fetch;
-    // freeze = methods.freeze;
+    freeze = methods.freeze;
     // thaw = methods.thaw;
     mapFreeze = methods.mapFreeze;
     mapThaw = methods.mapThaw;
@@ -143,8 +157,11 @@ HardDependencyBlockPlugin.prototype.apply = function(compiler) {
         block.blocks.length > 0
       ) {
         _frozen.dependencies = mapFreeze('Dependency', null, block.dependencies, extra);
+        assertFrozen(_frozen.dependencies, block.dependencies, 'dependencies', item => freeze('Dependency', null, item, extra));
         _frozen.variables = mapFreeze('DependencyVariable', null, block.variables, extra);
+        assertFrozen(_frozen.variables, block.variables, 'dependency variables', item => freeze('DependencyVariable', null, item, extra));
         _frozen.blocks = mapFreeze('DependencyBlock', null, block.blocks, extra);
+        assertFrozen(_frozen.blocks, block.blocks, 'blocks', item => freeze('DependencyBlock', null, item, extra));
       }
       if (block.parent) {
         _frozen.parent = true;
@@ -152,12 +169,18 @@ HardDependencyBlockPlugin.prototype.apply = function(compiler) {
       return _frozen;
     }
 
-    return {
+    const _frozenBlock = {
       type: 'DependenciesBlock',
       dependencies: mapFreeze('Dependency', null, block.dependencies, extra),
       variables: mapFreeze('DependencyVariable', null, block.variables, extra),
       blocks: mapFreeze('DependencyBlock', null, block.blocks, extra),
     };
+
+    assertFrozen(_frozenBlock.dependencies, block.dependencies, 'dependencies', item => freeze('Dependency', null, item, extra));
+    assertFrozen(_frozenBlock.variables, block.variables, 'dependency variables', item => freeze('DependencyVariable', null, item, extra));
+    assertFrozen(_frozenBlock.blocks, block.blocks, 'blocks', item => freeze('DependencyBlock', null, item, extra));
+
+    return _frozenBlock;
   });
 
   pluginCompat.tap(compiler, '_hardSourceThawDependencyVariable', 'HardDependencyBlockPlugin', function(variable, frozen, extra) {

--- a/lib/hard-module-mini-css-extract-plugin.js
+++ b/lib/hard-module-mini-css-extract-plugin.js
@@ -1,0 +1,43 @@
+var pluginCompat = require('./util/plugin-compat');
+
+function HardModuleMiniCssExtractPlugin() {}
+
+HardModuleMiniCssExtractPlugin.prototype.apply = function(compiler) {
+  let CssDependency;
+
+  pluginCompat.tap(compiler, 'make', 'HardModuleMiniCssExtractPlugin', function(compilation) {
+    const Dependencies = compilation.dependencyFactories.keys();
+    for (const Dep of Dependencies) {
+      if (Dep.name === 'CssDependency') {
+        CssDependency = Dep;
+        break;
+      }
+    }
+  });
+
+  pluginCompat.tap(compiler, '_hardSourceFreezeDependency', 'HardMiniCssExtractPlugin freeze', function(frozen, dependency, extra) {
+    if (dependency.constructor === CssDependency) {
+      return {
+        type: 'CssDependency',
+        line: {
+          identifier: dependency.identifier,
+          content: dependency.content,
+          media: dependency.media,
+          sourceMap: dependency.sourceMap,
+        },
+        context: dependency.context,
+        identifierIndex: dependency.identifierIndex
+      };
+    }
+    return frozen;
+  });
+
+  pluginCompat.tap(compiler, '_hardSourceThawDependency', 'HardMiniCssExtractPlugin', function(dependency, frozen, extra) {
+    if (frozen.type === 'CssDependency') {
+      return new CssDependency(frozen.line, frozen.context, frozen.identifierIndex);
+    }
+    return dependency;
+  });
+};
+
+module.exports = HardModuleMiniCssExtractPlugin;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "html-webpack-plugin": "^2.22.0",
     "level": "^2.1.1",
     "memory-fs": "^0.4.1",
+    "mini-css-extract-plugin": "^0.4.0",
     "mocha": "^3.0.2",
     "source-map": "^0.5.6",
     "style-loader": "^0.14.0",

--- a/tests/fixtures/plugin-mini-css-extract/index.css
+++ b/tests/fixtures/plugin-mini-css-extract/index.css
@@ -1,0 +1,3 @@
+.hello {
+  color: blue;
+}

--- a/tests/fixtures/plugin-mini-css-extract/index.js
+++ b/tests/fixtures/plugin-mini-css-extract/index.js
@@ -1,0 +1,1 @@
+require('./index.css');

--- a/tests/fixtures/plugin-mini-css-extract/webpack.config.js
+++ b/tests/fixtures/plugin-mini-css-extract/webpack.config.js
@@ -1,0 +1,32 @@
+var MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader'
+        ]
+      }
+    ]
+  },
+  plugins: [
+    new MiniCssExtractPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentHash: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/plugins-webpack-4.js
+++ b/tests/plugins-webpack-4.js
@@ -1,0 +1,13 @@
+var expect = require('chai').expect;
+
+var describeWP = require('./util').describeWP;
+var itCompilesTwice = require('./util').itCompilesTwice;
+var itCompilesHardModules = require('./util').itCompilesHardModules;
+
+describeWP(4)('plugin webpack 4 use', function() {
+
+  itCompilesTwice('plugin-mini-css-extract');
+  itCompilesTwice('plugin-mini-css-extract', {exportStats: true});
+  itCompilesHardModules('plugin-mini-css-extract', ['./index.css']);
+
+});


### PR DESCRIPTION
- Add MiniCssExtractPlugin support
- Gracefully fail to freeze modules when all of its dependencies cannot be frozen

In cases where external plugins add dependencies to a NormalModule that HardSourceWebpackPlugin does not anticipate. That dependency will not be frozen. Thawing a module with a missing dependency will cause an incomplete build. To avoid this HardSource will not freeze a module with a missing dependency so that the next build that module will rebuild normally.

MiniCssExtractPlugin is the recommended plugin for extracting css in webpack 4.