### PR TITLE
Ignore argument passed to runReadOrReset

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,7 @@ class HardSourceWebpackPlugin {
       'relativeHelpers',
     ]);
 
-    function runReadOrReset(compiler) {
+    function runReadOrReset(_compiler) {
       logger.unlock();
 
       if (!active) {


### PR DESCRIPTION
Fix #320 

First argument can be a Watcher or Compiler instance depending on the webpack hook being responded to. Already having a reference to the compiler we can ignore this argument.