### PR TITLE
Fix Append2 deletion logic

### DIFF
--- a/lib/SerializerAppend2.js
+++ b/lib/SerializerAppend2.js
@@ -64,30 +64,39 @@ class WriteOutput {
   }
 
   add(key, content) {
-    // Write content to a temporary buffer
-    let length = tmpBuffer.utf8Write(content);
-    while (length === tmpBuffer.length) {
-      tmpBuffer = Buffer.allocUnsafe(tmpBuffer.length * 2);
-      length = tmpBuffer.utf8Write(content);
+    if (content !== null) {
+      // Write content to a temporary buffer
+      let length = tmpBuffer.utf8Write(content);
+      while (length === tmpBuffer.length) {
+        tmpBuffer = Buffer.allocUnsafe(tmpBuffer.length * 2);
+        length = tmpBuffer.utf8Write(content);
+      }
+
+      const start = this.length;
+      const end = start + length;
+
+      // Ensure output buffer is long enough to add the new content
+      if (end > this.buffer.length) {
+        this.buffer = resizePow2(this.buffer, end);
+      }
+
+      // Copy temporary buffer to the end of the current output buffer
+      tmpBuffer.copy(this.buffer.slice(start, end));
+
+      this.table.push({
+        name: key,
+        start,
+        end,
+      });
+      this.length = end;
     }
-
-    const start = this.length;
-    const end = start + length;
-
-    // Ensure output buffer is long enough to add the new content
-    if (end > this.buffer.length) {
-      this.buffer = resizePow2(this.buffer, end);
+    else {
+      this.table.push({
+        name: key,
+        start: -1,
+        end: -1,
+      });
     }
-
-    // Copy temporary buffer to the end of the current output buffer
-    tmpBuffer.copy(this.buffer.slice(start, end));
-
-    this.table.push({
-      name: key,
-      start,
-      end,
-    });
-    this.length = end;
   }
 }
 
@@ -195,7 +204,10 @@ class Append2 {
 
             order[entry.name] = index;
 
-            if (entry.start !== entry.end) {
+            // Negative start positions are not set on the output. They are
+            // treated as if they were deleted in a prior write. A future
+            // compact will remove all instances of any old entries.
+            if (entry.start >= 0) {
               await new Promise(process.nextTick);
               const data = content.utf8Slice(entry.start, entry.end);
               if (this.autoParse) {
@@ -203,8 +215,9 @@ class Append2 {
               } else {
                 out[entry.name] = data;
               }
-            } else {
-              out[entry.name] = null;
+            }
+            else {
+              delete out[entry.name];
             }
           }
         }
@@ -287,14 +300,16 @@ class Append2 {
     }
   }
 
+  // Write out a log chunk once the file reaches the maximum chunk size.
   async _writeAtMax(output) {
     while (output.length >= MAX_CHUNK) {
       await this._markAndWrite(output);
     }
   }
 
-  async _writeAt1(output) {
-    while (output.length > 0) {
+  // Write out a log chunk if their is any entries in the table.
+  async _writeAtAny(output) {
+    while (output.table.length > 0) {
       await this._markAndWrite(output);
     }
   }
@@ -323,10 +338,15 @@ class Append2 {
           await this._writeAtMax(largeOutput);
         }
       }
+      else {
+        smallOutput.add(op.key, null);
+
+        await this._writeAtMax(smallOutput);
+      }
     }
 
-    await this._writeAt1(smallOutput);
-    await this._writeAt1(largeOutput);
+    await this._writeAtAny(smallOutput);
+    await this._writeAtAny(largeOutput);
 
     await Promise.all(outputPromises);
   }


### PR DESCRIPTION
Related to #330

Record deleted entries as entries with negative positions. When deleted
entries are read their keys are left or become unset or `delete`d.