### PR TITLE
Ensure file and context dependencies are absolute

### DIFF
--- a/index.js
+++ b/index.js
@@ -518,6 +518,10 @@ class HardSourceWebpackPlugin {
             relateNormalPath,
             relateNormalRequest,
             relateNormalModuleId,
+
+            contextNormalPath,
+            contextNormalRequest,
+            contextNormalModuleId,
           },
         ]),
       ]).then(() => {

--- a/lib/CacheMd5.js
+++ b/lib/CacheMd5.js
@@ -325,7 +325,7 @@ class Md5Cache {
       compiler,
       '_hardSourceWriteCache',
       'HardSource - Md5Cache',
-      (compilation, { relateNormalPath }) => {
+      (compilation, { relateNormalPath, contextNormalPath }) => {
         const moduleOps = [];
         const dataOps = [];
         const md5Ops = [];
@@ -369,28 +369,8 @@ class Md5Cache {
           });
         }
 
-        const fileDependencies = Array.from(compilation.fileDependencies);
-
-        // if (!lodash.isEqual(fileDependencies, dataCache.fileDependencies)) {
-        //   lodash.difference(dataCache.fileDependencies, fileDependencies).forEach(function(file) {
-        //     buildingMd5s[file] = {
-        //       mtime: 0,
-        //       hash: '',
-        //     };
-        //   });
-        //
-        //   dataCache.fileDependencies = fileDependencies;
-        //
-        //   dataOps.push({
-        //     key: 'fileDependencies',
-        //     value: JSON.stringify(
-        //       dataCache.fileDependencies
-        //       .map(function(dep) {
-        //         return relateNormalPath(compiler, dep);
-        //       })
-        //     ),
-        //   });
-        // }
+        const fileDependencies = Array.from(compilation.fileDependencies)
+        .map(file => contextNormalPath(compiler, file));
 
         const MD5_TIME_PRECISION_BUFFER = 2000;
 
@@ -421,28 +401,8 @@ class Md5Cache {
 
         buildMd5Ops(fileDependencies);
 
-        const contextDependencies = Array.from(compilation.contextDependencies);
-
-        // if (!lodash.isEqual(contextDependencies, dataCache.contextDependencies)) {
-        //   lodash.difference(dataCache.contextDependencies, contextDependencies).forEach(function(file) {
-        //     buildingMd5s[file] = {
-        //       mtime: 0,
-        //       hash: '',
-        //     };
-        //   });
-        //
-        //   dataCache.contextDependencies = contextDependencies;
-        //
-        //   dataOps.push({
-        //     key: 'contextDependencies',
-        //     value: JSON.stringify(
-        //       dataCache.contextDependencies
-        //       .map(function(dep) {
-        //         return relateNormalPath(compiler, dep);
-        //       })
-        //     ),
-        //   });
-        // }
+        const contextDependencies = Array.from(compilation.contextDependencies)
+        .map(file => contextNormalPath(compiler, file));
 
         const contexts = contextStamps(contextDependencies);
         contextDependencies.forEach(file => {

--- a/lib/util/relate-context.js
+++ b/lib/util/relate-context.js
@@ -88,7 +88,7 @@ const contextNormalPath = (exports.contextNormalPath = function contextNormalPat
   if (key === '') {
     return '';
   }
-  return path.join(compilerContext(compiler), key).replace(/\//g, path.sep);
+  return path.resolve(compilerContext(compiler), key).replace(/\//g, path.sep);
 });
 
 const contextNormalRequest = (exports.contextNormalRequest = function contextNormalRequest(


### PR DESCRIPTION
Related to #330

Do not trust compilation's file and contextDependencies to contain absolute paths. Ensure they are before working with them.