### PR TITLE
Always log messages to stderr

### DIFF
--- a/lib/ChalkLoggerPlugin.js
+++ b/lib/ChalkLoggerPlugin.js
@@ -89,29 +89,27 @@ class ChalkLoggerPlugin {
 
       const header = headerColor(`[${DEFAULT_LOGGER_PREFIX}${LOGGER_SEPARATOR}${compiler.__hardSource_shortConfigHash || value.from}]`);
 
+      // Always use warn or error so that output goes to stderr.
+      const consoleFn = value.level === 'error' ? console.error : console.warn;
+
       let handle = messages[value.data.id];
       if (!handle) {
         handle = messages.unrecognized;
       }
+
       if (handle) {
         if (handle.once) {
           if (!this.once[value.data.id]) {
             this.once[value.data.id] = true;
-            (console[value.level] || console.error).call(
-              console, header, color(handle.once(value)),
-            );
+            consoleFn.call(console, header, color(handle.once(value)));
           }
         }
         else if (handle.short) {
-          (console[value.level] || console.error).call(
-            console, header, color(handle.short(value)),
-          );
+          consoleFn.call(console, header, color(handle.short(value)));
         }
       }
       else {
-        (console[value.level] || console.error).call(
-          console, header, color(value.message),
-        );
+        consoleFn.call(console, header, color(value.message));
       }
     });
   }

--- a/lib/loggerFactory.js
+++ b/lib/loggerFactory.js
@@ -93,8 +93,7 @@ class Logger {
         value,
       );
     } else {
-      (console[value.level] || console.error).call(
-        console,
+      console.error(
         `[${DEFAULT_LOGGER_PREFIX}${LOGGER_SEPARATOR}${value.from}]`,
         value.message,
       );


### PR DESCRIPTION
Chalk logger work moved some common messages onto log level which goes to stdout. This will break uses of `webpack --json` which prints only the json data to stdout. Errors can safely go to stderr, letting the user get the stats json as well as normal error messages.