### PR TITLE
Report node dependency inputs once before cache read

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,7 @@ class HardSourceWebpackPlugin {
           hash += `_${_this.configHash}`;
         }
 
-        if (hashInputs) {
+        if (hashInputs && !cacheRead) {
           logMessages.environmentInputs(compiler, {inputs: hashInputs});
         }
 


### PR DESCRIPTION
Report inputs once for each root compiler.