### PR TITLE
Monkey patch mini-css for hash updating

### DIFF
--- a/lib/SupportMiniCssExtractPlugin.js
+++ b/lib/SupportMiniCssExtractPlugin.js
@@ -1,5 +1,13 @@
 const pluginCompat = require('./util/plugin-compat');
 
+const mixinCssDependency = function(CssDependency) {
+  const Dependency = Object.getPrototypeOf(CssDependency.prototype).constructor;
+  CssDependency.prototype.updateHash = function(hash) {
+    Dependency.prototype.updateHash.call(this, hash);
+    hash.update(this.content);
+  };
+};
+
 class SupportMiniCssExtractPlugin {
   apply(compiler) {
     let CssDependency;
@@ -13,6 +21,7 @@ class SupportMiniCssExtractPlugin {
         for (const Dep of Dependencies) {
           if (Dep.name === 'CssDependency') {
             CssDependency = Dep;
+            mixinCssDependency(CssDependency);
             break;
           }
         }

--- a/tests/fixtures/plugin-mini-css-extract-watch/index.css
+++ b/tests/fixtures/plugin-mini-css-extract-watch/index.css
@@ -1,0 +1,3 @@
+.hello {
+  color: red;
+}

--- a/tests/fixtures/plugin-mini-css-extract-watch/index.js
+++ b/tests/fixtures/plugin-mini-css-extract-watch/index.js
@@ -1,0 +1,1 @@
+require('./index.css');

--- a/tests/fixtures/plugin-mini-css-extract-watch/webpack.config.js
+++ b/tests/fixtures/plugin-mini-css-extract-watch/webpack.config.js
@@ -1,0 +1,32 @@
+var MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader'
+        ]
+      }
+    ]
+  },
+  plugins: [
+    new MiniCssExtractPlugin(),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentHash: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};

--- a/tests/plugins-webpack-4.js
+++ b/tests/plugins-webpack-4.js
@@ -4,6 +4,9 @@ var describeWP = require('./util').describeWP;
 var itCompilesTwice = require('./util').itCompilesTwice;
 var itCompilesHardModules = require('./util').itCompilesHardModules;
 var itCompilesChange = require('./util').itCompilesChange;
+var writeFiles = require('./util').writeFiles;
+var compile = require('./util').compile;
+var clean = require('./util').clean;
 
 var c = require('./util/features');
 
@@ -32,6 +35,65 @@ describeWP(4)('plugin webpack 4 use - builds change', function() {
   }, function(output) {
     expect(output.run1['main.css'].toString()).to.match(/blue/);
     expect(output.run2['main.css'].toString()).to.match(/red/);
+  });
+
+});
+
+describeWP(4)('plugin webpack 4 use - watch mode', function() {
+
+  it('plugin-mini-css-extract-watch: #339', function() {
+    this.timeout(60000);
+
+    return clean('plugin-mini-css-extract-watch')
+    .then(function() {
+      return writeFiles('plugin-mini-css-extract-watch', {
+        'index.css': [
+          '.hello {',
+          '  color: blue;',
+          '}',
+        ].join('\n'),
+      });
+    })
+    .then(function() {
+      return compile('plugin-mini-css-extract-watch', {
+        watch: 'start',
+      });
+    })
+    .then(function(result) {
+      return writeFiles('plugin-mini-css-extract-watch', {
+        'index.css': [
+          '.hello {',
+          '  color: red;',
+          '}',
+        ].join('\n'),
+      })
+      .then(function() {
+        return compile('plugin-mini-css-extract-watch', {
+          watching: result.watching,
+          watch: 'continue',
+        });
+      })
+      .then(function(result) {
+        return compile('plugin-mini-css-extract-watch', {
+          watching: result.watching,
+          watch: 'stop',
+        });
+      })
+      .then(function() {return result;});
+    })
+    .then(function(result) {
+      return compile('plugin-mini-css-extract-watch')
+      .then(function(result2) {
+        return {
+          result,
+          result2,
+        };
+      });
+    })
+    .then(function(results) {
+      expect(results.result2['main.css'].toString())
+        .to.not.equal(results.result.out['main.css'].toString());
+    });
   });
 
 });


### PR DESCRIPTION
Fix #339

- Add a regression test

Patch the CssDependency updateHash method so the owning module's hash updates when its depended on modules change as they store a copy of their data on the mini-css module.