### PR TITLE
fix: parse and stringify data in serializers

### DIFF
--- a/lib/CacheEnhancedResolve.js
+++ b/lib/CacheEnhancedResolve.js
@@ -28,11 +28,13 @@ class EnhancedResolveCache {
         missingCacheSerializer = cacheSerializerFactory.create({
           name: 'missing-resolve',
           type: 'data',
+          autoParse: true,
           cacheDirPath,
         });
         resolverCacheSerializer = cacheSerializerFactory.create({
           name: 'resolver',
           type: 'data',
+          autoParse: true,
           cacheDirPath,
         });
       },

--- a/lib/CacheMd5.js
+++ b/lib/CacheMd5.js
@@ -178,6 +178,7 @@ class Md5Cache {
         md5CacheSerializer = cacheSerializerFactory.create({
           name: 'md5',
           type: 'data',
+          autoParse: true,
           cacheDirPath,
         });
       },
@@ -371,7 +372,7 @@ class Md5Cache {
 
                 md5Ops.push({
                   key: relateNormalPath(compiler, file),
-                  value: JSON.stringify(value),
+                  value: value,
                 });
               } else if (
                 !value.mtime &&
@@ -463,7 +464,7 @@ class Md5Cache {
             for (const key in unbuildMd5s) {
               md5Ops.push({
                 key: relateNormalPath(compiler, key),
-                value: JSON.stringify(unbuildMd5s[key]),
+                value: unbuildMd5s[key],
               });
             }
           }

--- a/lib/CacheModuleResolver.js
+++ b/lib/CacheModuleResolver.js
@@ -22,6 +22,7 @@ class ModuleResolverCache {
         moduleResolveCacheSerializer = cacheSerializerFactory.create({
           name: 'module-resolve',
           type: 'data',
+          autoParse: true,
           cacheDirPath,
         });
       },
@@ -287,12 +288,7 @@ class ModuleResolverCache {
             moduleResolveOps.push({
               key: relateNormalModuleResolveKey(compiler, key),
               value: moduleResolveCache[key]
-                ? JSON.stringify(
-                    relateNormalModuleResolve(
-                      compiler,
-                      moduleResolveCache[key],
-                    ),
-                  )
+                ? relateNormalModuleResolve(compiler, moduleResolveCache[key])
                 : null,
             });
           });


### PR DESCRIPTION
Related to #330

Md5Cache stringified values outside of serializer. Stringifying null tells the serializer to store a string with the value 'null' instead of seeing a literal null value which instructs the serializer to delete that entry.