### PR TITLE
Allow custom values of info.mode and info.level

### DIFF
--- a/lib/ChalkLoggerPlugin.js
+++ b/lib/ChalkLoggerPlugin.js
@@ -66,10 +66,10 @@ class ChalkLoggerPlugin {
 
     // mode: 'test' or 'none'
     this.options.mode =
-      this.options.mode || process.env.NODE_ENV === 'test' ? 'test' : 'none';
+      this.options.mode || (process.env.NODE_ENV === 'test' ? 'test' : 'none');
     // level: 'error', 'warn', 'info', 'log', 'debug'
     this.options.level =
-      this.options.level || this.options.mode === 'test' ? 'warn' : 'debug';
+      this.options.level || (this.options.mode === 'test' ? 'warn' : 'debug');
   }
 
   apply(compiler) {


### PR DESCRIPTION
I tried to customize the info.mode and info.level options but failed to do so. The current code evaluates the OR statement as part of the conditional, i.e. this.options.mode = (this.options.mode || process.env.NODE_ENV === 'test') ? 'test' : 'none'; but I thinkg the intend here is this.options.mode = this.options.mode || (process.env.NODE_ENV === 'test' ? 'test' : 'none');