### PR TITLE
fix: store hashes in module cache

### DIFF
--- a/lib/TransformNormalModulePlugin.js
+++ b/lib/TransformNormalModulePlugin.js
@@ -169,13 +169,13 @@ const serialNormalModule4 = serial.serial('NormalModule', {
       {
         freeze(arg, module, extra) {
           const obj = {};
-          const cachedMd5s = compilation.__hardSourceCachedMd5s;
+          const cachedMd5s = extra.compilation.__hardSourceCachedMd5s;
 
           for (const file of module.buildInfo.fileDependencies) {
-            obj[file] = cachedHashes[file];
+            obj[file] = cachedMd5s[file];
           }
           for (const dir of module.buildInfo.contextDependencies) {
-            obj[dir] = cachedHashes[dir];
+            obj[dir] = cachedMd5s[dir];
           }
 
           return obj;

--- a/lib/TransformNormalModulePlugin.js
+++ b/lib/TransformNormalModulePlugin.js
@@ -28,28 +28,27 @@ const serialResolved = serial.created({
   // loaders: serial.loaders,
 });
 
-const serialResolvedMap = {
-  freeze(arg, module, extra) {
-    const resolved = [];
-    for (const key in arg) {
-      const thawedKey = JSON.parse(key);
-      resolved.push([
-        serialResolveRequest.freeze(thawedKey, thawedKey, extra),
-        serialResolved.freeze(arg[key], arg[key], extra),
-      ]);
-    }
-    return resolved;
+const serialJson = {
+  freeze(arg, value, extra) {
+    return JSON.parse(arg);
   },
   thaw(arg, frozen, extra) {
-    const resolved = {};
-    for (const item of arg) {
-      const key = serialResolveRequest.thaw(item[0], item[0], extra);
-      const value = serialResolved.thaw(item[1], item[1], extra);
-      resolved[JSON.stringify(key)] = value;
-    }
-    return resolved;
+    return JSON.stringify(arg);
   },
 };
+
+const serialMap = serial.map;
+
+const serialResolvedMap = serial.map(
+  serial.pipe(
+    { freeze: serialJson.freeze, thaw: serial.identity.thaw },
+    serialResolveRequest,
+    { freeze: serial.identity.freeze, thaw: serialJson.thaw },
+  ),
+  serialResolved,
+);
+
+const serialResourceHashMap = serial.map(serial.request, serial.identity);
 
 const serialNormalModule4 = serial.serial('NormalModule', {
   constructor: serial.constructed(NormalModule, {
@@ -166,6 +165,25 @@ const serialNormalModule4 = serial.serial('NormalModule', {
     _lastSuccessfulBuildMeta: serial.identity,
 
     __hardSource_resolved: serialResolvedMap,
+    __hardSource_oldHashes: serial.pipe(
+      {
+        freeze(arg, module, extra) {
+          const obj = {};
+          const cachedMd5s = compilation.__hardSourceCachedMd5s;
+
+          for (const file of module.buildInfo.fileDependencies) {
+            obj[file] = cachedHashes[file];
+          }
+          for (const dir of module.buildInfo.contextDependencies) {
+            obj[dir] = cachedHashes[dir];
+          }
+
+          return obj;
+        },
+        thaw: serial.identity.thaw,
+      },
+      serialResourceHashMap,
+    ),
   }),
 
   dependencyBlock: serial.dependencyBlock,
@@ -200,7 +218,7 @@ const needRebuild4 = function() {
     return true;
   }
   const fileHashes = this.__hardSourceFileMd5s;
-  const cachedHashes = this.__hardSourceCachedMd5s;
+  const cachedHashes = this.__hardSource_oldHashes;
   const resolvedLast = this.__hardSource_resolved;
   const missingCache = this.__hardSource_missingCache;
 
@@ -348,6 +366,25 @@ const serialNormalModule3 = serial.serial('NormalModule', {
     _source: serial.source,
 
     __hardSource_resolved: serialResolvedMap,
+    __hardSource_oldHashes: serial.pipe(
+      {
+        freeze(arg, module, extra) {
+          const obj = {};
+          const cachedMd5s = extra.compilation.__hardSourceCachedMd5s;
+
+          for (const file of module.fileDependencies) {
+            obj[file] = cachedMd5s[file];
+          }
+          for (const dir of module.contextDependencies) {
+            obj[dir] = cachedMd5s[dir];
+          }
+
+          return obj;
+        },
+        thaw: serial.identity.thaw,
+      },
+      serialResourceHashMap,
+    ),
   }),
 
   hash: {
@@ -392,7 +429,7 @@ const needRebuild3 = function() {
     return true;
   }
   const fileHashes = this.__hardSourceFileMd5s;
-  const cachedHashes = this.__hardSourceCachedMd5s;
+  const cachedHashes = this.__hardSource_oldHashes;
   const resolvedLast = this.__hardSource_resolved;
   const missingCache = this.__hardSource_missingCache;
 
@@ -557,6 +594,7 @@ class TransformNormalModulePlugin {
             module.cacheItem.invalid = false;
             module.cacheItem.invalidReason = null;
           }
+
           const f = serialNormalModule.freeze(
             null,
             module,

--- a/lib/util/serial.js
+++ b/lib/util/serial.js
@@ -15,6 +15,28 @@ const pipe = (exports.pipe = (...fns) => ({
   },
 }));
 
+const serialMap = (exports.map = (keyOp, valueOp) => ({
+  freeze(arg, module, extra) {
+    const resolved = [];
+    for (const key in arg) {
+      resolved.push([
+        keyOp.freeze(key, key, extra),
+        valueOp.freeze(arg[key], arg[key], extra),
+      ]);
+    }
+    return resolved;
+  },
+  thaw(arg, frozen, extra) {
+    const resolved = {};
+    for (const item of arg) {
+      const key = keyOp.thaw(item[0], item[0], extra);
+      const value = valueOp.thaw(item[1], item[1], extra);
+      resolved[key] = value;
+    }
+    return resolved;
+  },
+}));
+
 const contextual = (exports.contextual = fnname => {
   const relate = relateContext[`relateNormal${fnname}`];
   const context = relateContext[`contextNormal${fnname}`];


### PR DESCRIPTION
Close #338

Store hashes in module cache that help if the cache becomes "split" and stores hashes that do not represent the state of their respective items in the module cache. When a build next checks it may have caches that match but that that does not match what hashes the module cache should be.