### PR TITLE
fix: plus sign missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This uses the npm `node-object-hash` module with sort set to false to hash the o
 
 ```js
 configHash: function() {
-  return process.env.NODE_ENV + '-' process.env.BABEL_ENV;
+  return process.env.NODE_ENV + '-' + process.env.BABEL_ENV;
 }
 ```
 


### PR DESCRIPTION
There are some configurations that use webpack.DefinePlugin to define ENV. If use process.env.NODE_ENV, will get undefined. Do need to explain it in the documentation?