### PR TITLE
fix: use Buffer.alloc

### DIFF
--- a/lib/SerializerAppend2.js
+++ b/lib/SerializerAppend2.js
@@ -33,8 +33,8 @@ const TMP_CHUNK = 0.5 * 1024 * 1024;
 const MAX_CHUNK_PLUS = 2.5 * 1024 * 1024;
 const LARGE_CONTENT = 64 * 1024;
 
-let tmpBuffer = new Buffer(TMP_CHUNK);
-let outBuffer = new Buffer(MAX_CHUNK_PLUS);
+let tmpBuffer = Buffer.allocUnsafe(TMP_CHUNK);
+let outBuffer = Buffer.allocUnsafe(MAX_CHUNK_PLUS);
 
 const _buffers = [];
 
@@ -143,9 +143,9 @@ class Append2 {
     this.path = path;
     this.autoParse = autoParse;
 
-    this.inBuffer = new Buffer(0);
+    this.inBuffer = Buffer.alloc(0);
     this._buffers = [];
-    this.outBuffer = new Buffer(0);
+    this.outBuffer = Buffer.alloc(0);
   }
 
   async _readFile(file) {


### PR DESCRIPTION
Use Buffer.alloc and Buffer.allocUnsafe to remove Node 10 deprecation message around new Buffer.