### PR TITLE
fix: check default webpack rules

### DIFF
--- a/lib/util/serial.js
+++ b/lib/util/serial.js
@@ -77,7 +77,7 @@ const loaders = (exports.loaders = {
             let defaultRules = extra.compiler.options.module.defaultRules;
             let rules = extra.compiler.options.module.rules;
             const validRules = defaultRules ? defaultRules.concat(rules) : rules;
-            ruleSet = extra.compiler.__hardSource_ruleSet = new RuleSet(rules);
+            ruleSet = extra.compiler.__hardSource_ruleSet = new RuleSet(rules,);
           }
         }
         return {

--- a/lib/util/serial.js
+++ b/lib/util/serial.js
@@ -77,7 +77,7 @@ const loaders = (exports.loaders = {
             let defaultRules = extra.compiler.options.module.defaultRules;
             let rules = extra.compiler.options.module.rules;
             const validRules = defaultRules ? defaultRules.concat(rules) : rules;
-            ruleSet = extra.compiler.__hardSource_ruleSet = new RuleSet(validRules,);
+            ruleSet = extra.compiler.__hardSource_ruleSet = new RuleSet(validRules);
           }
         }
         return {

--- a/lib/util/serial.js
+++ b/lib/util/serial.js
@@ -74,11 +74,10 @@ const loaders = (exports.loaders = {
           ruleSet = extra.compiler.__hardSource_ruleSet;
           if (!ruleSet) {
             const RuleSet = require('webpack/lib/RuleSet');
-            ruleSet = extra.compiler.__hardSource_ruleSet = new RuleSet(
-              extra.compiler.options.module.defaultRules.concat(
-                extra.compiler.options.module.rules,
-              ),
-            );
+            let defaultRules = extra.compiler.options.module.defaultRules;
+            let rules = extra.compiler.options.module.rules;
+            const validRules = defaultRules ? defaultRules.concat(rules) : rules;
+            ruleSet = extra.compiler.__hardSource_ruleSet = new RuleSet(rules);
           }
         }
         return {

--- a/lib/util/serial.js
+++ b/lib/util/serial.js
@@ -77,7 +77,7 @@ const loaders = (exports.loaders = {
             let defaultRules = extra.compiler.options.module.defaultRules;
             let rules = extra.compiler.options.module.rules;
             const validRules = defaultRules ? defaultRules.concat(rules) : rules;
-            ruleSet = extra.compiler.__hardSource_ruleSet = new RuleSet(rules,);
+            ruleSet = extra.compiler.__hardSource_ruleSet = new RuleSet(validRules,);
           }
         }
         return {


### PR DESCRIPTION
I had a problem with the cache generation and this is now solved for me with these changes. This pull request may be shallow in many ways, but I wanted to share my solution. It is a simple checking on the default rules to use when requiring the Webpack RuleSet.

Package version: 0.11.0
Node version: 8.9.1
NPM version: 3.10.10

The error I got when I run the Webpack build (with vue-cli):

```
[hardsource:39ec245f] Using 41 MB of disk space.
[hardsource:39ec245f] Tracking node dependencies with: package-lock.json, yarn.lock.
[hardsource:39ec245f] Reading from cache 39ec245f...
[hardsource:39ec245f] Cache is corrupted.
TypeError: Cannot read property 'concat' of undefined
    at _loaders.thaw.map.loader (/opt/app-root/src/node_modules/hard-source-webpack-plugin/lib/util/serial.js:78:58)
    at Array.map (<anonymous>)
    at Object.thaw (/opt/app-root/src/node_modules/hard-source-webpack-plugin/lib/util/serial.js:69:55)
    at Object.thaw (/opt/app-root/src/node_modules/hard-source-webpack-plugin/lib/util/serial.js:171:28)
    at contextNormalModuleResolve (/opt/app-root/src/node_modules/hard-source-webpack-plugin/lib/CacheModuleResolver.js:202:38)
    at Object.keys.forEach.key (/opt/app-root/src/node_modules/hard-source-webpack-plugin/index.js:342:29)
    at Array.forEach (<anonymous>)
    at source (/opt/app-root/src/node_modules/hard-source-webpack-plugin/index.js:341:33)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
[hardsource:39ec245f] Last compilation did not finish saving. Building new cache.
```
This is my first pull request on Github, sorry if there's something wrong! Thanks for providing this great package to the community.