### PR TITLE
fix: serialize path query params without change

### DIFF
--- a/lib/util/relate-context.js
+++ b/lib/util/relate-context.js
@@ -90,7 +90,9 @@ const contextNormalPath = (exports.contextNormalPath = function contextNormalPat
     return '';
   }
   const abs = path.resolve(compilerContext(compiler), key.split('?')[0]);
-  return [abs.replace(/\//g, path.sep)].concat(key.split('?').slice(1)).join('?');
+  return [abs.replace(/\//g, path.sep)]
+    .concat(key.split('?').slice(1))
+    .join('?');
 });
 
 const contextNormalRequest = (exports.contextNormalRequest = function contextNormalRequest(

--- a/lib/util/relate-context.js
+++ b/lib/util/relate-context.js
@@ -26,7 +26,8 @@ const relateNormalPath = (exports.relateNormalPath = function relateNormalPath(
   if (key === '') {
     return key;
   }
-  return path.relative(compilerContext(compiler), key).replace(/\\/g, '/');
+  const rel = path.relative(compilerContext(compiler), key.split('?')[0]);
+  return [rel.replace(/\\/g, '/')].concat(key.split('?').slice(1)).join('?');
 });
 
 const relateNormalRequest = (exports.relateNormalRequest = function relateNormalRequest(
@@ -88,7 +89,8 @@ const contextNormalPath = (exports.contextNormalPath = function contextNormalPat
   if (key === '') {
     return '';
   }
-  return path.resolve(compilerContext(compiler), key).replace(/\//g, path.sep);
+  const abs = path.resolve(compilerContext(compiler), key.split('?')[0]);
+  return [abs.replace(/\//g, path.sep)].concat(key.split('?').slice(1)).join('?');
 });
 
 const contextNormalRequest = (exports.contextNormalRequest = function contextNormalRequest(

--- a/tests/base-webpack-3.js
+++ b/tests/base-webpack-3.js
@@ -7,12 +7,14 @@ var describeWP = require('./util').describeWP;
 
 describeWP(3)('basic webpack 3 use - compiles identically', function() {
 
+  itCompilesTwice('base-1dep-query');
+  itCompilesTwice('base-1dep-query', {exportStats: true});
+  itCompilesTwice('base-devtool-nosources-source-map');
+  itCompilesTwice('base-devtool-nosources-source-map', {exportStats: true});
   itCompilesTwice('base-es2015-module-export-star');
   itCompilesTwice('base-es2015-module-export-star', {exportStats: true});
   itCompilesTwice('base-es2015-module-export-star-alt');
   itCompilesTwice('base-es2015-module-export-star-alt', {exportStats: true});
-  itCompilesTwice('base-devtool-nosources-source-map');
-  itCompilesTwice('base-devtool-nosources-source-map', {exportStats: true});
 
   itCompilesHardModules('base-es2015-module-export-star', ['./export.js', './fab.js', './fib.js', './index.js']);
   itCompilesHardModules('base-es2015-module-export-star-alt', ['./export.js', './fab.js', './fib.js', './index.js']);

--- a/tests/fixtures/base-1dep-query/fib.js
+++ b/tests/fixtures/base-1dep-query/fib.js
@@ -1,0 +1,3 @@
+module.exports = function(n) {
+  return n + (n > 0 ? n - 1 : 0);
+};

--- a/tests/fixtures/base-1dep-query/index.js
+++ b/tests/fixtures/base-1dep-query/index.js
@@ -1,0 +1,3 @@
+var fib = require('./fib?http://localhost');
+
+console.log(fib(3));

--- a/tests/fixtures/base-1dep-query/webpack.config.js
+++ b/tests/fixtures/base-1dep-query/webpack.config.js
@@ -1,0 +1,18 @@
+var HardSourceWebpackPlugin = require('../../..');
+
+module.exports = {
+  context: __dirname,
+  entry: './index.js',
+  output: {
+    path: __dirname + '/tmp',
+    filename: 'main.js',
+  },
+  plugins: [
+    new HardSourceWebpackPlugin({
+      cacheDirectory: 'cache',
+      environmentHash: {
+        root: __dirname + '/../../..',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Fix #406

Module resolutions switched to util/serial serialization in 0.11 and
accidentally began modifying query params in paths like webpack uses to
instruct the dev-server/client where to connect the websocket to. Query
params in paths should not be modified as part of relating paths to the
compiler's context.