### PR TITLE
fix: performance regression due to false position md5

### DIFF
--- a/lib/TransformNormalModulePlugin.js
+++ b/lib/TransformNormalModulePlugin.js
@@ -218,7 +218,7 @@ const needRebuild4 = function() {
     return true;
   }
   const fileHashes = this.__hardSourceFileMd5s;
-  const cachedHashes = this.__hardSource_oldHashes;
+  const cachedHashes = this.__hardSourceCachedMd5s;
   const resolvedLast = this.__hardSource_resolved;
   const missingCache = this.__hardSource_missingCache;
 
@@ -429,7 +429,7 @@ const needRebuild3 = function() {
     return true;
   }
   const fileHashes = this.__hardSourceFileMd5s;
-  const cachedHashes = this.__hardSource_oldHashes;
+  const cachedHashes = this.__hardSourceCachedMd5s;
   const resolvedLast = this.__hardSource_resolved;
   const missingCache = this.__hardSource_missingCache;
 

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -465,7 +465,7 @@ exports.itCompilesHardModules = function(fixturePath, filesA, filesB, expectHand
     var shortener = new (require('webpack/lib/RequestShortener'))(path.resolve(__dirname, '../fixtures', fixturePath));
     function walk(compilation) {
       compilation.modules.forEach(function(module) {
-        if (module.cacheItem) {
+        if (module.cacheItem && module.buildTimestamp === module.cacheItem.build.buildTimestamp) {
           hardModules.push(module.readableIdentifier(shortener));
         }
       });


### PR DESCRIPTION
- improve hard modules test

Make sure the module used it's cached content and wasn't unbuilt and then rebuilt.