### PR TITLE
fix: memory leak in TransformNormalModuleFactoryPlugin

### DIFF
--- a/lib/TransformNormalModuleFactoryPlugin.js
+++ b/lib/TransformNormalModuleFactoryPlugin.js
@@ -38,11 +38,12 @@ class NormalModuleFactoryPlugin {
           'HardSource - TransformNormalModuleFactoryPlugin',
           module => {
             if (module.constructor.name === 'NormalModule') {
-              const _createLoaderContext = module.createLoaderContext;
+              module.__originalCreateLoaderContext =
+                module.__originalCreateLoaderContext ||
+                module.createLoaderContext;
               module.__hardSource_resolved = {};
               module.createLoaderContext = (...args) => {
-                const loaderContext = _createLoaderContext.call(
-                  module,
+                const loaderContext = module.__originalCreateLoaderContext(
                   ...args,
                 );
                 const _resolve = loaderContext.resolve;


### PR DESCRIPTION
Problem: plugin wraps createLoaderContext without checking if it was
already done before. As a result, in a watch mode more and more wrappers
get added on top of the function and eat more and more memory. Fixed by
saving original function on module instance itself and wrapping saved
function instead.

Fixes #409 