### PR TITLE
fix: replace native fs with graceful-fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 
 const lodash = require('lodash');

--- a/lib/SerializerAppend.js
+++ b/lib/SerializerAppend.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 const join = require('path').join;
 const Readable = require('stream').Readable;
 

--- a/lib/SerializerAppend2.js
+++ b/lib/SerializerAppend2.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 const { join, resolve } = require('path');
 const _mkdirp = require('mkdirp');
 const _rimraf = require('rimraf');

--- a/lib/SerializerFile.js
+++ b/lib/SerializerFile.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 const join = require('path').join;
 
 const _mkdirp = require('mkdirp');

--- a/lib/SerializerJson.js
+++ b/lib/SerializerJson.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 
 const promisify = require('./util/promisify');
 

--- a/lib/SystemPruneCaches.js
+++ b/lib/SystemPruneCaches.js
@@ -1,4 +1,4 @@
-const { readdir: _readdir, stat: _stat } = require('fs');
+const { readdir: _readdir, stat: _stat } = require('graceful-fs');
 const { basename, join } = require('path');
 
 const _rimraf = require('rimraf');

--- a/lib/TransformNormalModuleFactoryPlugin.js
+++ b/lib/TransformNormalModuleFactoryPlugin.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 
 const cachePrefix = require('./util').cachePrefix;

--- a/lib/envHash.js
+++ b/lib/envHash.js
@@ -6,7 +6,7 @@
 // - hash files
 
 const crypto = require('crypto');
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 
 const pkgDir = require('pkg-dir');

--- a/lib/schema-4/_generate.js
+++ b/lib/schema-4/_generate.js
@@ -454,7 +454,7 @@ const constructorArguments = {
   },
 **/
 
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 
 const generateRaw = fs.readFileSync(path.join(__dirname, '_generate.js'), 'utf8');
@@ -558,4 +558,4 @@ for (const dependency of dependencyInfo) {
 }
 output.push(``);
 
-require('fs').writeFileSync(require('path').join(__dirname, 'index.js'), output.join('\n'), 'utf8');
+require('graceful-fs').writeFileSync(require('path').join(__dirname, 'index.js'), output.join('\n'), 'utf8');

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 
 const logMessages = require('./log-messages');

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "find-cache-dir": "^2.0.0",
+    "graceful-fs": "^4.1.11",
     "jsonlint": "^1.6.3",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",

--- a/tests/fixtures/hard-source-confighash-dir/webpack.config.js
+++ b/tests/fixtures/hard-source-confighash-dir/webpack.config.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var HardSourceWebpackPlugin = require('../../..');
 

--- a/tests/fixtures/hard-source-confighash/webpack.config.js
+++ b/tests/fixtures/hard-source-confighash/webpack.config.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var HardSourceWebpackPlugin = require('../../..');
 

--- a/tests/fixtures/hard-source-environmenthash/loader.js
+++ b/tests/fixtures/hard-source-environmenthash/loader.js
@@ -1,3 +1,3 @@
 module.exports = function(source) {
-  return require('fs').readFileSync('./vendor/lib1.js') + source;
+  return require('graceful-fs').readFileSync('./vendor/lib1.js') + source;
 };

--- a/tests/fixtures/hard-source-environmenthash/webpack.config.js
+++ b/tests/fixtures/hard-source-environmenthash/webpack.config.js
@@ -1,10 +1,10 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var HardSourceWebpackPlugin = require('../../..');
 
 var hardSourceConfig = eval(
   '(function() { return (' +
-  require('fs')
+  require('graceful-fs')
   .readFileSync(__dirname + '/hard-source-config.js', 'utf8') +
   '); })'
 )();

--- a/tests/fixtures/hard-source-md5/webpack.config.js
+++ b/tests/fixtures/hard-source-md5/webpack.config.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var HardSourceWebpackPlugin = require('../../..');
 

--- a/tests/fixtures/hard-source-packageyarnlock-hash/loader.js
+++ b/tests/fixtures/hard-source-packageyarnlock-hash/loader.js
@@ -1,3 +1,3 @@
 module.exports = function(source) {
-  return require('fs').readFileSync('./vendor/lib1.js') + source;
+  return require('graceful-fs').readFileSync('./vendor/lib1.js') + source;
 };

--- a/tests/fixtures/hard-source-packageyarnlock-hash/webpack.config.js
+++ b/tests/fixtures/hard-source-packageyarnlock-hash/webpack.config.js
@@ -1,10 +1,10 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var HardSourceWebpackPlugin = require('../../..');
 
 var hardSourceConfig = eval(
   '(function() { return (' +
-  require('fs')
+  require('graceful-fs')
   .readFileSync(__dirname + '/hard-source-config.js', 'utf8') +
   '); })'
 )();

--- a/tests/fixtures/hard-source-prune/webpack.config.js
+++ b/tests/fixtures/hard-source-prune/webpack.config.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var HardSourceWebpackPlugin = require('../../..');
 

--- a/tests/fixtures/loader-custom-context-dep/loader.js
+++ b/tests/fixtures/loader-custom-context-dep/loader.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 module.exports = function(source) {

--- a/tests/fixtures/loader-custom-deep-context-dep/loader.js
+++ b/tests/fixtures/loader-custom-deep-context-dep/loader.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 module.exports = function(source) {

--- a/tests/fixtures/loader-custom-missing-dep-added/loader.js
+++ b/tests/fixtures/loader-custom-missing-dep-added/loader.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 module.exports = function(source) {

--- a/tests/fixtures/loader-custom-missing-dep/loader.js
+++ b/tests/fixtures/loader-custom-missing-dep/loader.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 module.exports = function(source) {

--- a/tests/fixtures/loader-custom-no-dep-moved/loader.js
+++ b/tests/fixtures/loader-custom-no-dep-moved/loader.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 module.exports = function(source) {};

--- a/tests/fixtures/loader-custom-no-dep/loader.js
+++ b/tests/fixtures/loader-custom-no-dep/loader.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 module.exports = function(source) {};

--- a/tests/fixtures/loader-custom-prepend-helper/loader.js
+++ b/tests/fixtures/loader-custom-prepend-helper/loader.js
@@ -2,5 +2,5 @@ module.exports = function(source) {
   this.cacheable && this.cacheable();
   var helperPath = require.resolve('./loader-helper.js');
   this.addDependency(helperPath);
-  return require('fs').readFileSync(helperPath, 'utf8') + source;
+  return require('graceful-fs').readFileSync(helperPath, 'utf8') + source;
 };

--- a/tests/hard-source.js
+++ b/tests/hard-source.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var expect = require('chai').expect;
 

--- a/tests/serializers.js
+++ b/tests/serializers.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var join = require('path').join;
 
 var expect = require('chai').expect;

--- a/tests/util/force-write-records.js
+++ b/tests/util/force-write-records.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 function ForceWriteRecords() {}

--- a/tests/util/index.js
+++ b/tests/util/index.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 var vm = require('vm');
 


### PR DESCRIPTION
webpack crash due to unix `too many open files` error in our large frontend project.