### PR TITLE
Fixes issue #443 by adding prefix to the HarmonyExportExpression model.

### DIFF
--- a/lib/TransformBasicDependencyPluginLegacy.js
+++ b/lib/TransformBasicDependencyPluginLegacy.js
@@ -111,6 +111,7 @@ const DependencySchemas2 = [
     'originModule',
     'range',
     'rangeStatement',
+    'prefix'
   ],
   ['HarmonyExportHeaderDependency', 'range', 'rangeStatement'],
   [
@@ -248,6 +249,7 @@ const DependencySchemas3 = [
     'originModule',
     'range',
     'rangeStatement',
+    'prefix'
   ],
   ['HarmonyExportHeaderDependency', 'range', 'rangeStatement'],
   [

--- a/lib/schema-4/basic-dependency.json
+++ b/lib/schema-4/basic-dependency.json
@@ -27,7 +27,8 @@
     "HarmonyExportExpressionDependency",
     "originModule",
     "range",
-    "rangeStatement"
+    "rangeStatement",
+    "prefix"
   ],
   ["HarmonyExportHeaderDependency", "range", "rangeStatement"],
   [

--- a/lib/schema-4/index.js
+++ b/lib/schema-4/index.js
@@ -549,6 +549,7 @@ const HarmonyExportExpressionDependencySerial = serial.serial('HarmonyExportExpr
         originModule: null,
         range: dependency.range,
         rangeStatement: dependency.rangeStatement,
+        prefix: dependency.prefix,
       };
     },
     thaw(thawed, frozen, extra, methods) {
@@ -556,6 +557,7 @@ const HarmonyExportExpressionDependencySerial = serial.serial('HarmonyExportExpr
         extra.module,
         frozen.range,
         frozen.rangeStatement,
+        frozen.prefix,
       );
     },
   },


### PR DESCRIPTION
This attempts to fix the recent regression of builds breaking.  @dreyks observed that PR #8039 in the webpack repo caused hard source to fail, and I've tried to balance out those changes in this PR. I was able to run two builds with out having to clear the cache, so that's a good sign. 

Hard source is great, thank you for your hard work.