### PR TITLE
Fix dependency specifier for webpack, fixes #448

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "source-map": "^0.5.6",
     "standard-version": "^4.4.0",
     "style-loader": "^0.14.0",
-    "webpack": "^4.0.0 || ^4.0.0-beta.* || ^3.8.1 || ^3.0.0 || ^3.0.0-rc.0 || ^2.1.0 || ^1.13.1",
+    "webpack": "^4.0.0 || ^4.0.0-beta.0 || ^3.8.1 || ^3.0.0 || ^3.0.0-rc.0 || ^2.1.0 || ^1.13.1",
     "webpack-cli": "^3.0.0",
     "webpack-isomorphic-tools": "^3.0.0",
     "worker-loader": "^2.0.0"


### PR DESCRIPTION
See #448 for details. "^4.0.0-beta.*" is syntactically incorrect, there is no "*" allowed at that location. Replaced that with "^4.0.0-beta.0".