### PR TITLE
Return value from updateMd5CacheItem to fix TypeErrors for property 'hash'

### DIFF
--- a/lib/CacheMd5.js
+++ b/lib/CacheMd5.js
@@ -382,6 +382,11 @@ class Md5Cache {
                 md5Cache[file] = value;
                 cachedMd5s[file] = value.hash;
               }
+
+              // If somehow dependencies operates on a file in both file and
+              // context, or otherwise doubles up, return value so the second
+              // call receives input.
+              return value;
             }
 
             const building = buildingMd5s[file];


### PR DESCRIPTION
This is a change by @mzgoddard himself that seems to fix #416 ([see here][1]). It should be included in the main repository to make the fix available for everyone.

  [1]: https://github.com/scalableminds/webknossos/pull/3239