### PR TITLE
Allow for bigint values in JSON.stringify

### DIFF
--- a/lib/SerializerAppend2.js
+++ b/lib/SerializerAppend2.js
@@ -333,7 +333,9 @@ class Append2 {
       if (op.value !== null) {
         let content = op.value;
         if (typeof content !== 'string') {
-          content = JSON.stringify(content);
+          content = typeof content === 'bigint'
+            ? content.toString()
+            : JSON.stringify(content);
         }
         if (content.length < LARGE_CONTENT) {
           smallOutput.add(op.key, content);


### PR DESCRIPTION
This change is as the result of a CI failure where bigint values are in-use -

https://github.com/LedgerHQ/ledger-live-desktop/runs/4325584600?check_suite_focus=true#step:13:92

Some background reading here - https://dev.to/benlesh/bigint-and-json-stringify-json-parse-2m8p

In this approach instead of adding a replacer, the typeof is just checked and then toString() is used on the value if found to be a bigint.